### PR TITLE
Begin adjusting styles for more maintainable development

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -7,7 +7,7 @@
 
 body {
     padding-top: 50px;
-    background-color: #212121;
+    background-color: #464444;
 }
 
 
@@ -216,16 +216,22 @@ body {
 }
 
 h1.page-header {
-    background-color: #514952;
     border-bottom: none;
     color: white;
-    padding-left: 5px;
     padding-top: 5px;
 }
 
 .grid-item1,
 .grid-item2 {
     margin-bottom: 5px;
+}
+
+.item-container {
+    border-bottom: 1px solid white;
+}
+
+.item-container:nth-of-type(even) {
+    background-color: #6D283F;
 }
 
 .footer {

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
                 <h1 class="page-header">Weapons</h1>
                 <div class="grid1" id="guns">
                     <div class="grid-item1" data-name="rusty sidearm" data-quality="6" data-type="Semiautomatic">
-                        <a href="#modalRusty-Sidearm" data-toggle="modal"><img alt="Rusty Sidearm" title="Rusty Sidearm" class="gameObject gameObject-Rusty-Sidearm" src="/img/trans.png"></a>
+                        <a href="#modalRusty-Sidearm" data-toggle="modal"><img alt="Rusty Sidearm" title="Rusty Sidearm" class="gameObject gameObject-Rusty-Sidearm" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRusty-Sidearm" tabindex="-1" role="dialog" aria-labelledby="Rusty-Sidearm" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -100,7 +100,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="marine sidearm" data-quality="6" data-type="Semiautomatic">
-                        <a href="#modalMarine-Sidearm" data-toggle="modal"><img alt="Marine Sidearm" title="Marine Sidearm" class="gameObject gameObject-Marine-Sidearm" src="/img/trans.png"></a>
+                        <a href="#modalMarine-Sidearm" data-toggle="modal"><img alt="Marine Sidearm" title="Marine Sidearm" class="gameObject gameObject-Marine-Sidearm" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMarine-Sidearm" tabindex="-1" role="dialog" aria-labelledby="Marine-Sidearm" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -128,7 +128,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="rogue special" data-quality="6" data-type="Semiautomatic">
-                        <a href="#modalRogue-Special" data-toggle="modal"><img alt="Rogue Special" title="Rogue Special" class="gameObject gameObject-Rogue-Special" src="/img/trans.png"></a>
+                        <a href="#modalRogue-Special" data-toggle="modal"><img alt="Rogue Special" title="Rogue Special" class="gameObject gameObject-Rogue-Special" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRogue-Special" tabindex="-1" role="dialog" aria-labelledby="Rogue-Special" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -156,7 +156,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="budget revolver" data-quality="6" data-type="Semiautomatic">
-                        <a href="#modalBudget-Revolver" data-toggle="modal"><img alt="Budget Revolver" title="Budget Revolver" class="gameObject gameObject-Budget-Revolver" src="/img/trans.png"></a>
+                        <a href="#modalBudget-Revolver" data-toggle="modal"><img alt="Budget Revolver" title="Budget Revolver" class="gameObject gameObject-Budget-Revolver" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBudget-Revolver" tabindex="-1" role="dialog" aria-labelledby="Budget-Revolver" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -184,7 +184,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="dart gun" data-quality="6" data-type="Semiautomatic">
-                        <a href="#modalDart-Gun" data-toggle="modal"><img alt="Dart Gun" title="Dart Gun" class="gameObject gameObject-Dart-Gun" src="/img/trans.png"></a>
+                        <a href="#modalDart-Gun" data-toggle="modal"><img alt="Dart Gun" title="Dart Gun" class="gameObject gameObject-Dart-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDart-Gun" tabindex="-1" role="dialog" aria-labelledby="Dart-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -212,7 +212,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="robot's right hand" data-quality="6" data-type="Semiautomatic">
-                        <a href="#modalRobot_s-Right-Hand" data-toggle="modal"><img alt="Robot's Right Hand" title="Robot's Right Hand" class="gameObject gameObject-Robot_s-Right-Hand" src="/img/trans.png"></a>
+                        <a href="#modalRobot_s-Right-Hand" data-toggle="modal"><img alt="Robot's Right Hand" title="Robot's Right Hand" class="gameObject gameObject-Robot_s-Right-Hand" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRobot_s-Right-Hand" tabindex="-1" role="dialog" aria-labelledby="Robot_s-Right-Hand" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -240,7 +240,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="blasphemy" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalBlasphemy" data-toggle="modal"><img alt="Blasphemy" title="Blasphemy" class="gameObject gameObject-Blasphemy" src="/img/trans.png"></a>
+                        <a href="#modalBlasphemy" data-toggle="modal"><img alt="Blasphemy" title="Blasphemy" class="gameObject gameObject-Blasphemy" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlasphemy" tabindex="-1" role="dialog" aria-labelledby="Blasphemy" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -268,7 +268,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="pea shooter" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalPea-Shooter" data-toggle="modal"><img alt="Pea Shooter" title="Pea Shooter" class="gameObject gameObject-Pea-Shooter" src="/img/trans.png"></a>
+                        <a href="#modalPea-Shooter" data-toggle="modal"><img alt="Pea Shooter" title="Pea Shooter" class="gameObject gameObject-Pea-Shooter" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPea-Shooter" tabindex="-1" role="dialog" aria-labelledby="Pea-Shooter" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -296,7 +296,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="38 special" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modal38-Special" data-toggle="modal"><img alt="38 Special" title="38 Special" class="gameObject gameObject-38-Special" src="/img/trans.png"></a>
+                        <a href="#modal38-Special" data-toggle="modal"><img alt="38 Special" title="38 Special" class="gameObject gameObject-38-Special" src="./img/trans.png"></a>
                         <div class="modal fade" id="modal38-Special" tabindex="-1" role="dialog" aria-labelledby="38-Special" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -324,7 +324,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="derringer" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalDerringer" data-toggle="modal"><img alt="Derringer" title="Derringer" class="gameObject gameObject-Derringer" src="/img/trans.png"></a>
+                        <a href="#modalDerringer" data-toggle="modal"><img alt="Derringer" title="Derringer" class="gameObject gameObject-Derringer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDerringer" tabindex="-1" role="dialog" aria-labelledby="Derringer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -352,7 +352,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="unfinished gun" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalUnfinished-Gun" data-toggle="modal"><img alt="Unfinished Gun" title="Unfinished Gun" class="gameObject gameObject-Unfinished-Gun" src="/img/trans.png"></a>
+                        <a href="#modalUnfinished-Gun" data-toggle="modal"><img alt="Unfinished Gun" title="Unfinished Gun" class="gameObject gameObject-Unfinished-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalUnfinished-Gun" tabindex="-1" role="dialog" aria-labelledby="Unfinished-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -380,7 +380,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="makarov" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalMakarov" data-toggle="modal"><img alt="Makarov" title="Makarov" class="gameObject gameObject-Makarov" src="/img/trans.png"></a>
+                        <a href="#modalMakarov" data-toggle="modal"><img alt="Makarov" title="Makarov" class="gameObject gameObject-Makarov" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMakarov" tabindex="-1" role="dialog" aria-labelledby="Makarov" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -408,7 +408,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="m1911" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalM1911" data-toggle="modal"><img alt="M1911" title="M1911" class="gameObject gameObject-M1911" src="/img/trans.png"></a>
+                        <a href="#modalM1911" data-toggle="modal"><img alt="M1911" title="M1911" class="gameObject gameObject-M1911" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalM1911" tabindex="-1" role="dialog" aria-labelledby="M1911" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -436,7 +436,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="magnum" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalMagnum" data-toggle="modal"><img alt="Magnum" title="Magnum" class="gameObject gameObject-Magnum" src="/img/trans.png"></a>
+                        <a href="#modalMagnum" data-toggle="modal"><img alt="Magnum" title="Magnum" class="gameObject gameObject-Magnum" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMagnum" tabindex="-1" role="dialog" aria-labelledby="Magnum" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -464,7 +464,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="colt 1851" data-quality="4" data-type="Burst">
-                        <a href="#modalColt-1851" data-toggle="modal"><img alt="Colt 1851" title="Colt 1851" class="gameObject gameObject-Colt-1851" src="/img/trans.png"></a>
+                        <a href="#modalColt-1851" data-toggle="modal"><img alt="Colt 1851" title="Colt 1851" class="gameObject gameObject-Colt-1851" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalColt-1851" tabindex="-1" role="dialog" aria-labelledby="Colt-1851" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -492,7 +492,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="saa" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalSAA" data-toggle="modal"><img alt="SAA" title="SAA" class="gameObject gameObject-SAA" src="/img/trans.png"></a>
+                        <a href="#modalSAA" data-toggle="modal"><img alt="SAA" title="SAA" class="gameObject gameObject-SAA" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSAA" tabindex="-1" role="dialog" aria-labelledby="SAA" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -520,7 +520,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="cold 45" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalCold-45" data-toggle="modal"><img alt="Cold 45" title="Cold 45" class="gameObject gameObject-Cold-45" src="/img/trans.png"></a>
+                        <a href="#modalCold-45" data-toggle="modal"><img alt="Cold 45" title="Cold 45" class="gameObject gameObject-Cold-45" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCold-45" tabindex="-1" role="dialog" aria-labelledby="Cold-45" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -548,7 +548,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="polaris" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalPolaris" data-toggle="modal"><img alt="Polaris" title="Polaris" class="gameObject gameObject-Polaris" src="/img/trans.png"></a>
+                        <a href="#modalPolaris" data-toggle="modal"><img alt="Polaris" title="Polaris" class="gameObject gameObject-Polaris" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPolaris" tabindex="-1" role="dialog" aria-labelledby="Polaris" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -576,7 +576,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="jolter" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalJolter" data-toggle="modal"><img alt="Jolter" title="Jolter" class="gameObject gameObject-Jolter" src="/img/trans.png"></a>
+                        <a href="#modalJolter" data-toggle="modal"><img alt="Jolter" title="Jolter" class="gameObject gameObject-Jolter" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalJolter" tabindex="-1" role="dialog" aria-labelledby="Jolter" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -604,7 +604,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="dungeon eagle" data-quality="4" data-type="Charged">
-                        <a href="#modalDungeon-Eagle" data-toggle="modal"><img alt="Dungeon Eagle" title="Dungeon Eagle" class="gameObject gameObject-Dungeon-Eagle" src="/img/trans.png"></a>
+                        <a href="#modalDungeon-Eagle" data-toggle="modal"><img alt="Dungeon Eagle" title="Dungeon Eagle" class="gameObject gameObject-Dungeon-Eagle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDungeon-Eagle" tabindex="-1" role="dialog" aria-labelledby="Dungeon-Eagle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -632,7 +632,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="grey mauser" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalGrey-Mauser" data-toggle="modal"><img alt="Grey Mauser" title="Grey Mauser" class="gameObject gameObject-Grey-Mauser" src="/img/trans.png"></a>
+                        <a href="#modalGrey-Mauser" data-toggle="modal"><img alt="Grey Mauser" title="Grey Mauser" class="gameObject gameObject-Grey-Mauser" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGrey-Mauser" tabindex="-1" role="dialog" aria-labelledby="Grey-Mauser" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -660,7 +660,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="shellegun" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalShellegun" data-toggle="modal"><img alt="Shellegun" title="Shellegun" class="gameObject gameObject-Shellegun" src="/img/trans.png"></a>
+                        <a href="#modalShellegun" data-toggle="modal"><img alt="Shellegun" title="Shellegun" class="gameObject gameObject-Shellegun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShellegun" tabindex="-1" role="dialog" aria-labelledby="Shellegun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -688,7 +688,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="dueling pistol" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalDueling-Pistol" data-toggle="modal"><img alt="Dueling Pistol" title="Dueling Pistol" class="gameObject gameObject-Dueling-Pistol" src="/img/trans.png"></a>
+                        <a href="#modalDueling-Pistol" data-toggle="modal"><img alt="Dueling Pistol" title="Dueling Pistol" class="gameObject gameObject-Dueling-Pistol" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDueling-Pistol" tabindex="-1" role="dialog" aria-labelledby="Dueling-Pistol" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -716,7 +716,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="au gun" data-quality="1" data-type="Semiautomatic">
-                        <a href="#modalAU-Gun" data-toggle="modal"><img alt="AU Gun" title="AU Gun" class="gameObject gameObject-AU-Gun" src="/img/trans.png"></a>
+                        <a href="#modalAU-Gun" data-toggle="modal"><img alt="AU Gun" title="AU Gun" class="gameObject gameObject-AU-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAU-Gun" tabindex="-1" role="dialog" aria-labelledby="AU-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -744,7 +744,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="big iron" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalBig-Iron" data-toggle="modal"><img alt="Big Iron" title="Big Iron" class="gameObject gameObject-Big-Iron" src="/img/trans.png"></a>
+                        <a href="#modalBig-Iron" data-toggle="modal"><img alt="Big Iron" title="Big Iron" class="gameObject gameObject-Big-Iron" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBig-Iron" tabindex="-1" role="dialog" aria-labelledby="Big-Iron" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -772,7 +772,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="composite gun" data-quality="1" data-type="Charged">
-                        <a href="#modalComposite-Gun" data-toggle="modal"><img alt="Composite Gun" title="Composite Gun" class="gameObject gameObject-Composite-Gun" src="/img/trans.png"></a>
+                        <a href="#modalComposite-Gun" data-toggle="modal"><img alt="Composite Gun" title="Composite Gun" class="gameObject gameObject-Composite-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalComposite-Gun" tabindex="-1" role="dialog" aria-labelledby="Composite-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -800,7 +800,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="flare gun" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalFlare-Gun" data-toggle="modal"><img alt="Flare Gun" title="Flare Gun" class="gameObject gameObject-Flare-Gun" src="/img/trans.png"></a>
+                        <a href="#modalFlare-Gun" data-toggle="modal"><img alt="Flare Gun" title="Flare Gun" class="gameObject gameObject-Flare-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFlare-Gun" tabindex="-1" role="dialog" aria-labelledby="Flare-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -828,7 +828,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="smiley's revolver" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalSmiley_s-Revolver" data-toggle="modal"><img alt="Smiley's Revolver" title="Smiley's Revolver" class="gameObject gameObject-Smiley_s-Revolver" src="/img/trans.png"></a>
+                        <a href="#modalSmiley_s-Revolver" data-toggle="modal"><img alt="Smiley's Revolver" title="Smiley's Revolver" class="gameObject gameObject-Smiley_s-Revolver" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSmiley_s-Revolver" tabindex="-1" role="dialog" aria-labelledby="Smiley_s-Revolver" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -856,7 +856,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="shades's revolver" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalShades_s-Revolver" data-toggle="modal"><img alt="Shades's Revolver" title="Shades's Revolver" class="gameObject gameObject-Shades_s-Revolver" src="/img/trans.png"></a>
+                        <a href="#modalShades_s-Revolver" data-toggle="modal"><img alt="Shades's Revolver" title="Shades's Revolver" class="gameObject gameObject-Shades_s-Revolver" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShades_s-Revolver" tabindex="-1" role="dialog" aria-labelledby="Shades_s-Revolver" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -884,7 +884,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="regular shotgun" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalRegular-Shotgun" data-toggle="modal"><img alt="Regular Shotgun" title="Regular Shotgun" class="gameObject gameObject-Regular-Shotgun" src="/img/trans.png"></a>
+                        <a href="#modalRegular-Shotgun" data-toggle="modal"><img alt="Regular Shotgun" title="Regular Shotgun" class="gameObject gameObject-Regular-Shotgun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRegular-Shotgun" tabindex="-1" role="dialog" aria-labelledby="Regular-Shotgun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -912,7 +912,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="old goldie" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalOld-Goldie" data-toggle="modal"><img alt="Old Goldie" title="Old Goldie" class="gameObject gameObject-Old-Goldie" src="/img/trans.png"></a>
+                        <a href="#modalOld-Goldie" data-toggle="modal"><img alt="Old Goldie" title="Old Goldie" class="gameObject gameObject-Old-Goldie" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOld-Goldie" tabindex="-1" role="dialog" aria-labelledby="Old-Goldie" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -940,7 +940,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="sawed-off" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalSawed-Off" data-toggle="modal"><img alt="Sawed-Off" title="Sawed-Off" class="gameObject gameObject-Sawed-Off" src="/img/trans.png"></a>
+                        <a href="#modalSawed-Off" data-toggle="modal"><img alt="Sawed-Off" title="Sawed-Off" class="gameObject gameObject-Sawed-Off" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSawed-Off" tabindex="-1" role="dialog" aria-labelledby="Sawed-Off" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -968,7 +968,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="winchester" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalWinchester" data-toggle="modal"><img alt="Winchester" title="Winchester" class="gameObject gameObject-Winchester" src="/img/trans.png"></a>
+                        <a href="#modalWinchester" data-toggle="modal"><img alt="Winchester" title="Winchester" class="gameObject gameObject-Winchester" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWinchester" tabindex="-1" role="dialog" aria-labelledby="Winchester" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -996,7 +996,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="rattler" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalRattler" data-toggle="modal"><img alt="Rattler" title="Rattler" class="gameObject gameObject-Rattler" src="/img/trans.png"></a>
+                        <a href="#modalRattler" data-toggle="modal"><img alt="Rattler" title="Rattler" class="gameObject gameObject-Rattler" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRattler" tabindex="-1" role="dialog" aria-labelledby="Rattler" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1024,7 +1024,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="elephant gun" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalElephant-Gun" data-toggle="modal"><img alt="Elephant Gun" title="Elephant Gun" class="gameObject gameObject-Elephant-Gun" src="/img/trans.png"></a>
+                        <a href="#modalElephant-Gun" data-toggle="modal"><img alt="Elephant Gun" title="Elephant Gun" class="gameObject gameObject-Elephant-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalElephant-Gun" tabindex="-1" role="dialog" aria-labelledby="Elephant-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1052,7 +1052,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="tangler" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalTangler" data-toggle="modal"><img alt="Tangler" title="Tangler" class="gameObject gameObject-Tangler" src="/img/trans.png"></a>
+                        <a href="#modalTangler" data-toggle="modal"><img alt="Tangler" title="Tangler" class="gameObject gameObject-Tangler" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTangler" tabindex="-1" role="dialog" aria-labelledby="Tangler" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1080,7 +1080,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="void shotgun" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalVoid-Shotgun" data-toggle="modal"><img alt="Void Shotgun" title="Void Shotgun" class="gameObject gameObject-Void-Shotgun" src="/img/trans.png"></a>
+                        <a href="#modalVoid-Shotgun" data-toggle="modal"><img alt="Void Shotgun" title="Void Shotgun" class="gameObject gameObject-Void-Shotgun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalVoid-Shotgun" tabindex="-1" role="dialog" aria-labelledby="Void-Shotgun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1108,7 +1108,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="mass shotgun" data-quality="3" data-type="Automatic">
-                        <a href="#modalMass-Shotgun" data-toggle="modal"><img alt="Mass Shotgun" title="Mass Shotgun" class="gameObject gameObject-Mass-Shotgun" src="/img/trans.png"></a>
+                        <a href="#modalMass-Shotgun" data-toggle="modal"><img alt="Mass Shotgun" title="Mass Shotgun" class="gameObject gameObject-Mass-Shotgun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMass-Shotgun" tabindex="-1" role="dialog" aria-labelledby="Mass-Shotgun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1136,7 +1136,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="shotgun full of hate" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalShotgun-Full-of-Hate" data-toggle="modal"><img alt="Shotgun Full of Hate" title="Shotgun Full of Hate" class="gameObject gameObject-Shotgun-Full-of-Hate" src="/img/trans.png"></a>
+                        <a href="#modalShotgun-Full-of-Hate" data-toggle="modal"><img alt="Shotgun Full of Hate" title="Shotgun Full of Hate" class="gameObject gameObject-Shotgun-Full-of-Hate" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShotgun-Full-of-Hate" tabindex="-1" role="dialog" aria-labelledby="Shotgun-Full-of-Hate" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1164,7 +1164,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="shotgun full of love" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalShotgun-Full-of-Love" data-toggle="modal"><img alt="Shotgun Full of Love" title="Shotgun Full of Love" class="gameObject gameObject-Shotgun-Full-of-Love" src="/img/trans.png"></a>
+                        <a href="#modalShotgun-Full-of-Love" data-toggle="modal"><img alt="Shotgun Full of Love" title="Shotgun Full of Love" class="gameObject gameObject-Shotgun-Full-of-Love" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShotgun-Full-of-Love" tabindex="-1" role="dialog" aria-labelledby="Shotgun-Full-of-Love" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1192,7 +1192,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="shotgrub" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalShotgrub" data-toggle="modal"><img alt="Shotgrub" title="Shotgrub" class="gameObject gameObject-Shotgrub" src="/img/trans.png"></a>
+                        <a href="#modalShotgrub" data-toggle="modal"><img alt="Shotgrub" title="Shotgrub" class="gameObject gameObject-Shotgrub" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShotgrub" tabindex="-1" role="dialog" aria-labelledby="Shotgrub" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1220,7 +1220,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gilded hydra" data-quality="1" data-type="Semiautomatic">
-                        <a href="#modalGilded-Hydra" data-toggle="modal"><img alt="Gilded Hydra" title="Gilded Hydra" class="gameObject gameObject-Gilded-Hydra" src="/img/trans.png"></a>
+                        <a href="#modalGilded-Hydra" data-toggle="modal"><img alt="Gilded Hydra" title="Gilded Hydra" class="gameObject gameObject-Gilded-Hydra" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGilded-Hydra" tabindex="-1" role="dialog" aria-labelledby="Gilded-Hydra" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1248,7 +1248,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="blunderbuss" data-quality="5" data-type="Charged">
-                        <a href="#modalBlunderbuss" data-toggle="modal"><img alt="Blunderbuss" title="Blunderbuss" class="gameObject gameObject-Blunderbuss" src="/img/trans.png"></a>
+                        <a href="#modalBlunderbuss" data-toggle="modal"><img alt="Blunderbuss" title="Blunderbuss" class="gameObject gameObject-Blunderbuss" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlunderbuss" tabindex="-1" role="dialog" aria-labelledby="Blunderbuss" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1276,7 +1276,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="pulse cannon" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalPulse-Cannon" data-toggle="modal"><img alt="Pulse Cannon" title="Pulse Cannon" class="gameObject gameObject-Pulse-Cannon" src="/img/trans.png"></a>
+                        <a href="#modalPulse-Cannon" data-toggle="modal"><img alt="Pulse Cannon" title="Pulse Cannon" class="gameObject gameObject-Pulse-Cannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPulse-Cannon" tabindex="-1" role="dialog" aria-labelledby="Pulse-Cannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1304,7 +1304,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="siren" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalSiren" data-toggle="modal"><img alt="Siren" title="Siren" class="gameObject gameObject-Siren" src="/img/trans.png"></a>
+                        <a href="#modalSiren" data-toggle="modal"><img alt="Siren" title="Siren" class="gameObject gameObject-Siren" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSiren" tabindex="-1" role="dialog" aria-labelledby="Siren" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1332,7 +1332,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="zilla shotgun" data-quality="2" data-type="Charged">
-                        <a href="#modalZilla-Shotgun" data-toggle="modal"><img alt="Zilla Shotgun" title="Zilla Shotgun" class="gameObject gameObject-Zilla-Shotgun" src="/img/trans.png"></a>
+                        <a href="#modalZilla-Shotgun" data-toggle="modal"><img alt="Zilla Shotgun" title="Zilla Shotgun" class="gameObject gameObject-Zilla-Shotgun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalZilla-Shotgun" tabindex="-1" role="dialog" aria-labelledby="Zilla-Shotgun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1360,7 +1360,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="ice breaker" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalIce-Breaker" data-toggle="modal"><img alt="Ice Breaker" title="Ice Breaker" class="gameObject gameObject-Ice-Breaker" src="/img/trans.png"></a>
+                        <a href="#modalIce-Breaker" data-toggle="modal"><img alt="Ice Breaker" title="Ice Breaker" class="gameObject gameObject-Ice-Breaker" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalIce-Breaker" tabindex="-1" role="dialog" aria-labelledby="Ice-Breaker" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1388,7 +1388,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="the membrane" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalThe-Membrane" data-toggle="modal"><img alt="The Membrane" title="The Membrane" class="gameObject gameObject-The-Membrane" src="/img/trans.png"></a>
+                        <a href="#modalThe-Membrane" data-toggle="modal"><img alt="The Membrane" title="The Membrane" class="gameObject gameObject-The-Membrane" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalThe-Membrane" tabindex="-1" role="dialog" aria-labelledby="The-Membrane" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1416,7 +1416,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="huntsman" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalHuntsman" data-toggle="modal"><img alt="Huntsman" title="Huntsman" class="gameObject gameObject-Huntsman" src="/img/trans.png"></a>
+                        <a href="#modalHuntsman" data-toggle="modal"><img alt="Huntsman" title="Huntsman" class="gameObject gameObject-Huntsman" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHuntsman" tabindex="-1" role="dialog" aria-labelledby="Huntsman" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1444,7 +1444,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="blooper" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalBlooper" data-toggle="modal"><img alt="Blooper" title="Blooper" class="gameObject gameObject-Blooper" src="/img/trans.png"></a>
+                        <a href="#modalBlooper" data-toggle="modal"><img alt="Blooper" title="Blooper" class="gameObject gameObject-Blooper" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlooper" tabindex="-1" role="dialog" aria-labelledby="Blooper" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1472,7 +1472,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="bow" data-quality="4" data-type="Charged">
-                        <a href="#modalBow" data-toggle="modal"><img alt="Bow" title="Bow" class="gameObject gameObject-Bow" src="/img/trans.png"></a>
+                        <a href="#modalBow" data-toggle="modal"><img alt="Bow" title="Bow" class="gameObject gameObject-Bow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBow" tabindex="-1" role="dialog" aria-labelledby="Bow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1500,7 +1500,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="charmed bow" data-quality="3" data-type="Charged">
-                        <a href="#modalCharmed-Bow" data-toggle="modal"><img alt="Charmed Bow" title="Charmed Bow" class="gameObject gameObject-Charmed-Bow" src="/img/trans.png"></a>
+                        <a href="#modalCharmed-Bow" data-toggle="modal"><img alt="Charmed Bow" title="Charmed Bow" class="gameObject gameObject-Charmed-Bow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCharmed-Bow" tabindex="-1" role="dialog" aria-labelledby="Charmed-Bow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1528,7 +1528,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="crossbow" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalCrossbow" data-toggle="modal"><img alt="Crossbow" title="Crossbow" class="gameObject gameObject-Crossbow" src="/img/trans.png"></a>
+                        <a href="#modalCrossbow" data-toggle="modal"><img alt="Crossbow" title="Crossbow" class="gameObject gameObject-Crossbow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCrossbow" tabindex="-1" role="dialog" aria-labelledby="Crossbow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1556,7 +1556,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="sticky crossbow" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalSticky-Crossbow" data-toggle="modal"><img alt="Sticky Crossbow" title="Sticky Crossbow" class="gameObject gameObject-Sticky-Crossbow" src="/img/trans.png"></a>
+                        <a href="#modalSticky-Crossbow" data-toggle="modal"><img alt="Sticky Crossbow" title="Sticky Crossbow" class="gameObject gameObject-Sticky-Crossbow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSticky-Crossbow" tabindex="-1" role="dialog" aria-labelledby="Sticky-Crossbow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1584,7 +1584,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="shotbow" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalShotbow" data-toggle="modal"><img alt="Shotbow" title="Shotbow" class="gameObject gameObject-Shotbow" src="/img/trans.png"></a>
+                        <a href="#modalShotbow" data-toggle="modal"><img alt="Shotbow" title="Shotbow" class="gameObject gameObject-Shotbow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShotbow" tabindex="-1" role="dialog" aria-labelledby="Shotbow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1612,7 +1612,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="triple crossbow" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalTriple-Crossbow" data-toggle="modal"><img alt="Triple Crossbow" title="Triple Crossbow" class="gameObject gameObject-Triple-Crossbow" src="/img/trans.png"></a>
+                        <a href="#modalTriple-Crossbow" data-toggle="modal"><img alt="Triple Crossbow" title="Triple Crossbow" class="gameObject gameObject-Triple-Crossbow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTriple-Crossbow" tabindex="-1" role="dialog" aria-labelledby="Triple-Crossbow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1640,7 +1640,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="crescent crossbow" data-quality="2" data-type="Charged">
-                        <a href="#modalCrescent-Crossbow" data-toggle="modal"><img alt="Crescent Crossbow" title="Crescent Crossbow" class="gameObject gameObject-Crescent-Crossbow" src="/img/trans.png"></a>
+                        <a href="#modalCrescent-Crossbow" data-toggle="modal"><img alt="Crescent Crossbow" title="Crescent Crossbow" class="gameObject gameObject-Crescent-Crossbow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCrescent-Crossbow" tabindex="-1" role="dialog" aria-labelledby="Crescent-Crossbow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1668,7 +1668,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gunbow" data-quality="2" data-type="Charged">
-                        <a href="#modalGunbow" data-toggle="modal"><img alt="Gunbow" title="Gunbow" class="gameObject gameObject-Gunbow" src="/img/trans.png"></a>
+                        <a href="#modalGunbow" data-toggle="modal"><img alt="Gunbow" title="Gunbow" class="gameObject gameObject-Gunbow" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunbow" tabindex="-1" role="dialog" aria-labelledby="Gunbow" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1696,7 +1696,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="klobbe" data-quality="5" data-type="Automatic">
-                        <a href="#modalKlobbe" data-toggle="modal"><img alt="Klobbe" title="Klobbe" class="gameObject gameObject-Klobbe" src="/img/trans.png"></a>
+                        <a href="#modalKlobbe" data-toggle="modal"><img alt="Klobbe" title="Klobbe" class="gameObject gameObject-Klobbe" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalKlobbe" tabindex="-1" role="dialog" aria-labelledby="Klobbe" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1724,7 +1724,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="machine pistol" data-quality="5" data-type="Automatic">
-                        <a href="#modalMachine-Pistol" data-toggle="modal"><img alt="Machine Pistol" title="Machine Pistol" class="gameObject gameObject-Machine-Pistol" src="/img/trans.png"></a>
+                        <a href="#modalMachine-Pistol" data-toggle="modal"><img alt="Machine Pistol" title="Machine Pistol" class="gameObject gameObject-Machine-Pistol" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMachine-Pistol" tabindex="-1" role="dialog" aria-labelledby="Machine-Pistol" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1752,7 +1752,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="thompson sub-machinegun" data-quality="4" data-type="Automatic">
-                        <a href="#modalThompson-Sub-Machinegun" data-toggle="modal"><img alt="Thompson Sub-Machinegun" title="Thompson Sub-Machinegun" class="gameObject gameObject-Thompson-Sub-Machinegun" src="/img/trans.png"></a>
+                        <a href="#modalThompson-Sub-Machinegun" data-toggle="modal"><img alt="Thompson Sub-Machinegun" title="Thompson Sub-Machinegun" class="gameObject gameObject-Thompson-Sub-Machinegun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalThompson-Sub-Machinegun" tabindex="-1" role="dialog" aria-labelledby="Thompson-Sub-Machinegun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1780,7 +1780,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="ak-47" data-quality="3" data-type="Automatic">
-                        <a href="#modalAK-47" data-toggle="modal"><img alt="AK-47" title="AK-47" class="gameObject gameObject-AK-47" src="/img/trans.png"></a>
+                        <a href="#modalAK-47" data-toggle="modal"><img alt="AK-47" title="AK-47" class="gameObject gameObject-AK-47" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAK-47" tabindex="-1" role="dialog" aria-labelledby="AK-47" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1808,7 +1808,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="akey-47" data-quality="1" data-type="Automatic">
-                        <a href="#modalAKEY-47" data-toggle="modal"><img alt="AKEY-47" title="AKEY-47" class="gameObject gameObject-AKEY-47" src="/img/trans.png"></a>
+                        <a href="#modalAKEY-47" data-toggle="modal"><img alt="AKEY-47" title="AKEY-47" class="gameObject gameObject-AKEY-47" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAKEY-47" tabindex="-1" role="dialog" aria-labelledby="AKEY-47" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1836,7 +1836,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="m16" data-quality="2" data-type="Burst">
-                        <a href="#modalM16" data-toggle="modal"><img alt="M16" title="M16" class="gameObject gameObject-M16" src="/img/trans.png"></a>
+                        <a href="#modalM16" data-toggle="modal"><img alt="M16" title="M16" class="gameObject gameObject-M16" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalM16" tabindex="-1" role="dialog" aria-labelledby="M16" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1864,7 +1864,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="zorgun" data-quality="2" data-type="Automatic">
-                        <a href="#modalZorgun" data-toggle="modal"><img alt="Zorgun" title="Zorgun" class="gameObject gameObject-Zorgun" src="/img/trans.png"></a>
+                        <a href="#modalZorgun" data-toggle="modal"><img alt="Zorgun" title="Zorgun" class="gameObject gameObject-Zorgun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalZorgun" tabindex="-1" role="dialog" aria-labelledby="Zorgun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1892,7 +1892,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="vertebraek-47" data-quality="3" data-type="Automatic">
-                        <a href="#modalVertebraeK-47" data-toggle="modal"><img alt="VertebraeK-47" title="VertebraeK-47" class="gameObject gameObject-VertebraeK-47" src="/img/trans.png"></a>
+                        <a href="#modalVertebraeK-47" data-toggle="modal"><img alt="VertebraeK-47" title="VertebraeK-47" class="gameObject gameObject-VertebraeK-47" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalVertebraeK-47" tabindex="-1" role="dialog" aria-labelledby="VertebraeK-47" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1920,7 +1920,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="mac10" data-quality="4" data-type="Burst">
-                        <a href="#modalMAC10" data-toggle="modal"><img alt="MAC10" title="MAC10" class="gameObject gameObject-MAC10" src="/img/trans.png"></a>
+                        <a href="#modalMAC10" data-toggle="modal"><img alt="MAC10" title="MAC10" class="gameObject gameObject-MAC10" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMAC10" tabindex="-1" role="dialog" aria-labelledby="MAC10" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1948,7 +1948,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="heck blaster" data-quality="2" data-type="Automatic">
-                        <a href="#modalHeck-Blaster" data-toggle="modal"><img alt="Heck Blaster" title="Heck Blaster" class="gameObject gameObject-Heck-Blaster" src="/img/trans.png"></a>
+                        <a href="#modalHeck-Blaster" data-toggle="modal"><img alt="Heck Blaster" title="Heck Blaster" class="gameObject gameObject-Heck-Blaster" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeck-Blaster" tabindex="-1" role="dialog" aria-labelledby="Heck-Blaster" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -1976,7 +1976,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="patriot" data-quality="1" data-type="Automatic">
-                        <a href="#modalPatriot" data-toggle="modal"><img alt="Patriot" title="Patriot" class="gameObject gameObject-Patriot" src="/img/trans.png"></a>
+                        <a href="#modalPatriot" data-toggle="modal"><img alt="Patriot" title="Patriot" class="gameObject gameObject-Patriot" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPatriot" tabindex="-1" role="dialog" aria-labelledby="Patriot" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2004,7 +2004,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="vulcan cannon" data-quality="1" data-type="Automatic">
-                        <a href="#modalVulcan-Cannon" data-toggle="modal"><img alt="Vulcan Cannon" title="Vulcan Cannon" class="gameObject gameObject-Vulcan-Cannon" src="/img/trans.png"></a>
+                        <a href="#modalVulcan-Cannon" data-toggle="modal"><img alt="Vulcan Cannon" title="Vulcan Cannon" class="gameObject gameObject-Vulcan-Cannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalVulcan-Cannon" tabindex="-1" role="dialog" aria-labelledby="Vulcan-Cannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2032,7 +2032,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="plague pistol" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalPlague-Pistol" data-toggle="modal"><img alt="Plague Pistol" title="Plague Pistol" class="gameObject gameObject-Plague-Pistol" src="/img/trans.png"></a>
+                        <a href="#modalPlague-Pistol" data-toggle="modal"><img alt="Plague Pistol" title="Plague Pistol" class="gameObject gameObject-Plague-Pistol" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPlague-Pistol" tabindex="-1" role="dialog" aria-labelledby="Plague-Pistol" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2060,7 +2060,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gungine" data-quality="1" data-type="Automatic">
-                        <a href="#modalGungine" data-toggle="modal"><img alt="Gungine" title="Gungine" class="gameObject gameObject-Gungine" src="/img/trans.png"></a>
+                        <a href="#modalGungine" data-toggle="modal"><img alt="Gungine" title="Gungine" class="gameObject gameObject-Gungine" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGungine" tabindex="-1" role="dialog" aria-labelledby="Gungine" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2088,7 +2088,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="dragunfire" data-quality="2" data-type="Automatic">
-                        <a href="#modalDragunfire" data-toggle="modal"><img alt="Dragunfire" title="Dragunfire" class="gameObject gameObject-Dragunfire" src="/img/trans.png"></a>
+                        <a href="#modalDragunfire" data-toggle="modal"><img alt="Dragunfire" title="Dragunfire" class="gameObject gameObject-Dragunfire" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDragunfire" tabindex="-1" role="dialog" aria-labelledby="Dragunfire" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2116,7 +2116,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="sniper rifle" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalSniper-Rifle" data-toggle="modal"><img alt="Sniper Rifle" title="Sniper Rifle" class="gameObject gameObject-Sniper-Rifle" src="/img/trans.png"></a>
+                        <a href="#modalSniper-Rifle" data-toggle="modal"><img alt="Sniper Rifle" title="Sniper Rifle" class="gameObject gameObject-Sniper-Rifle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSniper-Rifle" tabindex="-1" role="dialog" aria-labelledby="Sniper-Rifle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2144,7 +2144,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="a.w.p." data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalA-W-P-" data-toggle="modal"><img alt="A.W.P." title="A.W.P." class="gameObject gameObject-A-W-P-" src="/img/trans.png"></a>
+                        <a href="#modalA-W-P-" data-toggle="modal"><img alt="A.W.P." title="A.W.P." class="gameObject gameObject-A-W-P-" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalA-W-P-" tabindex="-1" role="dialog" aria-labelledby="A-W.P." aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2172,7 +2172,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="m1" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalM1" data-toggle="modal"><img alt="M1" title="M1" class="gameObject gameObject-M1" src="/img/trans.png"></a>
+                        <a href="#modalM1" data-toggle="modal"><img alt="M1" title="M1" class="gameObject gameObject-M1" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalM1" tabindex="-1" role="dialog" aria-labelledby="M1" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2200,7 +2200,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="winchester rifle" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalWinchester-Rifle" data-toggle="modal"><img alt="Winchester Rifle" title="Winchester Rifle" class="gameObject gameObject-Winchester-Rifle" src="/img/trans.png"></a>
+                        <a href="#modalWinchester-Rifle" data-toggle="modal"><img alt="Winchester Rifle" title="Winchester Rifle" class="gameObject gameObject-Winchester-Rifle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWinchester-Rifle" tabindex="-1" role="dialog" aria-labelledby="Winchester-Rifle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2228,7 +2228,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="corsair" data-quality="4" data-type="Charged">
-                        <a href="#modalCorsair" data-toggle="modal"><img alt="Corsair" title="Corsair" class="gameObject gameObject-Corsair" src="/img/trans.png"></a>
+                        <a href="#modalCorsair" data-toggle="modal"><img alt="Corsair" title="Corsair" class="gameObject gameObject-Corsair" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCorsair" tabindex="-1" role="dialog" aria-labelledby="Corsair" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2256,7 +2256,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="railgun" data-quality="1" data-type="Charged">
-                        <a href="#modalRailgun" data-toggle="modal"><img alt="Railgun" title="Railgun" class="gameObject gameObject-Railgun" src="/img/trans.png"></a>
+                        <a href="#modalRailgun" data-toggle="modal"><img alt="Railgun" title="Railgun" class="gameObject gameObject-Railgun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRailgun" tabindex="-1" role="dialog" aria-labelledby="Railgun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2284,7 +2284,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="prototype railgun" data-quality="2" data-type="Charged">
-                        <a href="#modalPrototype-Railgun" data-toggle="modal"><img alt="Prototype Railgun" title="Prototype Railgun" class="gameObject gameObject-Prototype-Railgun" src="/img/trans.png"></a>
+                        <a href="#modalPrototype-Railgun" data-toggle="modal"><img alt="Prototype Railgun" title="Prototype Railgun" class="gameObject gameObject-Prototype-Railgun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPrototype-Railgun" tabindex="-1" role="dialog" aria-labelledby="Prototype-Railgun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2312,7 +2312,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="void marshal" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalVoid-Marshal" data-toggle="modal"><img alt="Void Marshal" title="Void Marshal" class="gameObject gameObject-Void-Marshal" src="/img/trans.png"></a>
+                        <a href="#modalVoid-Marshal" data-toggle="modal"><img alt="Void Marshal" title="Void Marshal" class="gameObject gameObject-Void-Marshal" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalVoid-Marshal" tabindex="-1" role="dialog" aria-labelledby="Void-Marshal" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2340,7 +2340,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="deck4rd" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalDeck4rd" data-toggle="modal"><img alt="Deck4rd" title="Deck4rd" class="gameObject gameObject-Deck4rd" src="/img/trans.png"></a>
+                        <a href="#modalDeck4rd" data-toggle="modal"><img alt="Deck4rd" title="Deck4rd" class="gameObject gameObject-Deck4rd" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDeck4rd" tabindex="-1" role="dialog" aria-labelledby="Deck4rd" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2368,7 +2368,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="the judge" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalThe-Judge" data-toggle="modal"><img alt="The Judge" title="The Judge" class="gameObject gameObject-The-Judge" src="/img/trans.png"></a>
+                        <a href="#modalThe-Judge" data-toggle="modal"><img alt="The Judge" title="The Judge" class="gameObject gameObject-The-Judge" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalThe-Judge" tabindex="-1" role="dialog" aria-labelledby="The-Judge" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2396,7 +2396,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="alien sidearm" data-quality="5" data-type="Charged">
-                        <a href="#modalAlien-Sidearm" data-toggle="modal"><img alt="Alien Sidearm" title="Alien Sidearm" class="gameObject gameObject-Alien-Sidearm" src="/img/trans.png"></a>
+                        <a href="#modalAlien-Sidearm" data-toggle="modal"><img alt="Alien Sidearm" title="Alien Sidearm" class="gameObject gameObject-Alien-Sidearm" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAlien-Sidearm" tabindex="-1" role="dialog" aria-labelledby="Alien-Sidearm" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2424,7 +2424,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="rube-adyne prototype" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalRUBE-ADYNE-Prototype" data-toggle="modal"><img alt="RUBE-ADYNE Prototype" title="RUBE-ADYNE Prototype" class="gameObject gameObject-RUBE-ADYNE-Prototype" src="/img/trans.png"></a>
+                        <a href="#modalRUBE-ADYNE-Prototype" data-toggle="modal"><img alt="RUBE-ADYNE Prototype" title="RUBE-ADYNE Prototype" class="gameObject gameObject-RUBE-ADYNE-Prototype" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRUBE-ADYNE-Prototype" tabindex="-1" role="dialog" aria-labelledby="RUBE-ADYNE-Prototype" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2452,7 +2452,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="rube-adyne mk.ii" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalRUBE-ADYNE-MK-II" data-toggle="modal"><img alt="RUBE-ADYNE MK.II" title="RUBE-ADYNE MK.II" class="gameObject gameObject-RUBE-ADYNE-MK-II" src="/img/trans.png"></a>
+                        <a href="#modalRUBE-ADYNE-MK-II" data-toggle="modal"><img alt="RUBE-ADYNE MK.II" title="RUBE-ADYNE MK.II" class="gameObject gameObject-RUBE-ADYNE-MK-II" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRUBE-ADYNE-MK-II" tabindex="-1" role="dialog" aria-labelledby="RUBE-ADYNE-MK-II" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2480,7 +2480,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="mine cutter" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalMine-Cutter" data-toggle="modal"><img alt="Mine Cutter" title="Mine Cutter" class="gameObject gameObject-Mine-Cutter" src="/img/trans.png"></a>
+                        <a href="#modalMine-Cutter" data-toggle="modal"><img alt="Mine Cutter" title="Mine Cutter" class="gameObject gameObject-Mine-Cutter" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMine-Cutter" tabindex="-1" role="dialog" aria-labelledby="Mine-Cutter" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2508,7 +2508,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="void core assault rifle" data-quality="3" data-type="Burst">
-                        <a href="#modalVoid-Core-Assault-Rifle" data-toggle="modal"><img alt="Void Core Assault Rifle" title="Void Core Assault Rifle" class="gameObject gameObject-Void-Core-Assault-Rifle" src="/img/trans.png"></a>
+                        <a href="#modalVoid-Core-Assault-Rifle" data-toggle="modal"><img alt="Void Core Assault Rifle" title="Void Core Assault Rifle" class="gameObject gameObject-Void-Core-Assault-Rifle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalVoid-Core-Assault-Rifle" tabindex="-1" role="dialog" aria-labelledby="Void-Core-Assault-Rifle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2536,7 +2536,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="flash ray" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalFlash-Ray" data-toggle="modal"><img alt="Flash Ray" title="Flash Ray" class="gameObject gameObject-Flash-Ray" src="/img/trans.png"></a>
+                        <a href="#modalFlash-Ray" data-toggle="modal"><img alt="Flash Ray" title="Flash Ray" class="gameObject gameObject-Flash-Ray" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFlash-Ray" tabindex="-1" role="dialog" aria-labelledby="Flash-Ray" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2564,7 +2564,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="wind up gun" data-quality="5" data-type="Automatic">
-                        <a href="#modalWind-Up-Gun" data-toggle="modal"><img alt="Wind Up Gun" title="Wind Up Gun" class="gameObject gameObject-Wind-Up-Gun" src="/img/trans.png"></a>
+                        <a href="#modalWind-Up-Gun" data-toggle="modal"><img alt="Wind Up Gun" title="Wind Up Gun" class="gameObject gameObject-Wind-Up-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWind-Up-Gun" tabindex="-1" role="dialog" aria-labelledby="Wind-Up-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2592,7 +2592,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="h4mmer" data-quality="3" data-type="Automatic">
-                        <a href="#modalH4mmer" data-toggle="modal"><img alt="H4mmer" title="H4mmer" class="gameObject gameObject-H4mmer" src="/img/trans.png"></a>
+                        <a href="#modalH4mmer" data-toggle="modal"><img alt="H4mmer" title="H4mmer" class="gameObject gameObject-H4mmer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalH4mmer" tabindex="-1" role="dialog" aria-labelledby="H4mmer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2620,7 +2620,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="snakemaker" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalSnakemaker" data-toggle="modal"><img alt="Snakemaker" title="Snakemaker" class="gameObject gameObject-Snakemaker" src="/img/trans.png"></a>
+                        <a href="#modalSnakemaker" data-toggle="modal"><img alt="Snakemaker" title="Snakemaker" class="gameObject gameObject-Snakemaker" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSnakemaker" tabindex="-1" role="dialog" aria-labelledby="Snakemaker" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2648,7 +2648,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="hegemony carbine" data-quality="4" data-type="Automatic">
-                        <a href="#modalHegemony-Carbine" data-toggle="modal"><img alt="Hegemony Carbine" title="Hegemony Carbine" class="gameObject gameObject-Hegemony-Carbine" src="/img/trans.png"></a>
+                        <a href="#modalHegemony-Carbine" data-toggle="modal"><img alt="Hegemony Carbine" title="Hegemony Carbine" class="gameObject gameObject-Hegemony-Carbine" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHegemony-Carbine" tabindex="-1" role="dialog" aria-labelledby="Hegemony-Carbine" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2676,7 +2676,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="screecher" data-quality="4" data-type="Automatic">
-                        <a href="#modalScreecher" data-toggle="modal"><img alt="Screecher" title="Screecher" class="gameObject gameObject-Screecher" src="/img/trans.png"></a>
+                        <a href="#modalScreecher" data-toggle="modal"><img alt="Screecher" title="Screecher" class="gameObject gameObject-Screecher" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalScreecher" tabindex="-1" role="dialog" aria-labelledby="Screecher" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2704,7 +2704,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="laser lotus" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalLaser-Lotus" data-toggle="modal"><img alt="Laser Lotus" title="Laser Lotus" class="gameObject gameObject-Laser-Lotus" src="/img/trans.png"></a>
+                        <a href="#modalLaser-Lotus" data-toggle="modal"><img alt="Laser Lotus" title="Laser Lotus" class="gameObject gameObject-Laser-Lotus" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLaser-Lotus" tabindex="-1" role="dialog" aria-labelledby="Laser-Lotus" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2732,7 +2732,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="hegemony rifle" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalHegemony-Rifle" data-toggle="modal"><img alt="Hegemony Rifle" title="Hegemony Rifle" class="gameObject gameObject-Hegemony-Rifle" src="/img/trans.png"></a>
+                        <a href="#modalHegemony-Rifle" data-toggle="modal"><img alt="Hegemony Rifle" title="Hegemony Rifle" class="gameObject gameObject-Hegemony-Rifle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHegemony-Rifle" tabindex="-1" role="dialog" aria-labelledby="Hegemony-Rifle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2760,7 +2760,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="fightsabre" data-quality="1" data-type="Automatic">
-                        <a href="#modalFightsabre" data-toggle="modal"><img alt="Fightsabre" title="Fightsabre" class="gameObject gameObject-Fightsabre" src="/img/trans.png"></a>
+                        <a href="#modalFightsabre" data-toggle="modal"><img alt="Fightsabre" title="Fightsabre" class="gameObject gameObject-Fightsabre" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFightsabre" tabindex="-1" role="dialog" aria-labelledby="Fightsabre" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2788,7 +2788,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="helix" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalHelix" data-toggle="modal"><img alt="Helix" title="Helix" class="gameObject gameObject-Helix" src="/img/trans.png"></a>
+                        <a href="#modalHelix" data-toggle="modal"><img alt="Helix" title="Helix" class="gameObject gameObject-Helix" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHelix" tabindex="-1" role="dialog" aria-labelledby="Helix" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2816,7 +2816,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="laser rifle" data-quality="4" data-type="Burst">
-                        <a href="#modalLaser-Rifle" data-toggle="modal"><img alt="Laser Rifle" title="Laser Rifle" class="gameObject gameObject-Laser-Rifle" src="/img/trans.png"></a>
+                        <a href="#modalLaser-Rifle" data-toggle="modal"><img alt="Laser Rifle" title="Laser Rifle" class="gameObject gameObject-Laser-Rifle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLaser-Rifle" tabindex="-1" role="dialog" aria-labelledby="Laser-Rifle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2844,7 +2844,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="crestfaller" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalCrestfaller" data-toggle="modal"><img alt="Crestfaller" title="Crestfaller" class="gameObject gameObject-Crestfaller" src="/img/trans.png"></a>
+                        <a href="#modalCrestfaller" data-toggle="modal"><img alt="Crestfaller" title="Crestfaller" class="gameObject gameObject-Crestfaller" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCrestfaller" tabindex="-1" role="dialog" aria-labelledby="Crestfaller" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2872,7 +2872,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="thunderclap" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalThunderclap" data-toggle="modal"><img alt="Thunderclap" title="Thunderclap" class="gameObject gameObject-Thunderclap" src="/img/trans.png"></a>
+                        <a href="#modalThunderclap" data-toggle="modal"><img alt="Thunderclap" title="Thunderclap" class="gameObject gameObject-Thunderclap" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalThunderclap" tabindex="-1" role="dialog" aria-labelledby="Thunderclap" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2900,7 +2900,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="charge shot" data-quality="3" data-type="Charged">
-                        <a href="#modalCharge-Shot" data-toggle="modal"><img alt="Charge Shot" title="Charge Shot" class="gameObject gameObject-Charge-Shot" src="/img/trans.png"></a>
+                        <a href="#modalCharge-Shot" data-toggle="modal"><img alt="Charge Shot" title="Charge Shot" class="gameObject gameObject-Charge-Shot" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCharge-Shot" tabindex="-1" role="dialog" aria-labelledby="Charge-Shot" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2928,7 +2928,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="dark marker" data-quality="1" data-type="Semiautomatic">
-                        <a href="#modalDark-Marker" data-toggle="modal"><img alt="Dark Marker" title="Dark Marker" class="gameObject gameObject-Dark-Marker" src="/img/trans.png"></a>
+                        <a href="#modalDark-Marker" data-toggle="modal"><img alt="Dark Marker" title="Dark Marker" class="gameObject gameObject-Dark-Marker" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDark-Marker" tabindex="-1" role="dialog" aria-labelledby="Dark-Marker" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2956,7 +2956,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="particulator" data-quality="1" data-type="Semiautomatic">
-                        <a href="#modalParticulator" data-toggle="modal"><img alt="Particulator" title="Particulator" class="gameObject gameObject-Particulator" src="/img/trans.png"></a>
+                        <a href="#modalParticulator" data-toggle="modal"><img alt="Particulator" title="Particulator" class="gameObject gameObject-Particulator" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalParticulator" tabindex="-1" role="dialog" aria-labelledby="Particulator" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -2984,7 +2984,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="the emperor" data-quality="2" data-type="Burst">
-                        <a href="#modalThe-Emperor" data-toggle="modal"><img alt="The Emperor" title="The Emperor" class="gameObject gameObject-The-Emperor" src="/img/trans.png"></a>
+                        <a href="#modalThe-Emperor" data-toggle="modal"><img alt="The Emperor" title="The Emperor" class="gameObject gameObject-The-Emperor" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalThe-Emperor" tabindex="-1" role="dialog" aria-labelledby="The-Emperor" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3012,7 +3012,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="rpg" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalRPG" data-toggle="modal"><img alt="RPG" title="RPG" class="gameObject gameObject-RPG" src="/img/trans.png"></a>
+                        <a href="#modalRPG" data-toggle="modal"><img alt="RPG" title="RPG" class="gameObject gameObject-RPG" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRPG" tabindex="-1" role="dialog" aria-labelledby="RPG" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3040,7 +3040,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="grenade launcher" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalGrenade-Launcher" data-toggle="modal"><img alt="Grenade Launcher" title="Grenade Launcher" class="gameObject gameObject-Grenade-Launcher" src="/img/trans.png"></a>
+                        <a href="#modalGrenade-Launcher" data-toggle="modal"><img alt="Grenade Launcher" title="Grenade Launcher" class="gameObject gameObject-Grenade-Launcher" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGrenade-Launcher" tabindex="-1" role="dialog" aria-labelledby="Grenade-Launcher" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3068,7 +3068,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="stinger" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalStinger" data-toggle="modal"><img alt="Stinger" title="Stinger" class="gameObject gameObject-Stinger" src="/img/trans.png"></a>
+                        <a href="#modalStinger" data-toggle="modal"><img alt="Stinger" title="Stinger" class="gameObject gameObject-Stinger" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalStinger" tabindex="-1" role="dialog" aria-labelledby="Stinger" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3096,7 +3096,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="com4nd0" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalCom4nd0" data-toggle="modal"><img alt="Com4nd0" title="Com4nd0" class="gameObject gameObject-Com4nd0" src="/img/trans.png"></a>
+                        <a href="#modalCom4nd0" data-toggle="modal"><img alt="Com4nd0" title="Com4nd0" class="gameObject gameObject-Com4nd0" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCom4nd0" tabindex="-1" role="dialog" aria-labelledby="Com4nd0" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3124,7 +3124,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="rc rocket" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalRC-Rocket" data-toggle="modal"><img alt="RC Rocket" title="RC Rocket" class="gameObject gameObject-RC-Rocket" src="/img/trans.png"></a>
+                        <a href="#modalRC-Rocket" data-toggle="modal"><img alt="RC Rocket" title="RC Rocket" class="gameObject gameObject-RC-Rocket" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRC-Rocket" tabindex="-1" role="dialog" aria-labelledby="RC-Rocket" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3152,7 +3152,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="yari launcher" data-quality="1" data-type="Automatic">
-                        <a href="#modalYari-Launcher" data-toggle="modal"><img alt="Yari Launcher" title="Yari Launcher" class="gameObject gameObject-Yari-Launcher" src="/img/trans.png"></a>
+                        <a href="#modalYari-Launcher" data-toggle="modal"><img alt="Yari Launcher" title="Yari Launcher" class="gameObject gameObject-Yari-Launcher" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalYari-Launcher" tabindex="-1" role="dialog" aria-labelledby="Yari-Launcher" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3180,7 +3180,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="lil' bomber" data-quality="5" data-type="Charged">
-                        <a href="#modalLil_-Bomber" data-toggle="modal"><img alt="Lil' Bomber" title="Lil' Bomber" class="gameObject gameObject-Lil_-Bomber" src="/img/trans.png"></a>
+                        <a href="#modalLil_-Bomber" data-toggle="modal"><img alt="Lil' Bomber" title="Lil' Bomber" class="gameObject gameObject-Lil_-Bomber" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLil_-Bomber" tabindex="-1" role="dialog" aria-labelledby="Lil_-Bomber" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3208,7 +3208,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="grasschopper" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalGrasschopper" data-toggle="modal"><img alt="Grasschopper" title="Grasschopper" class="gameObject gameObject-Grasschopper" src="/img/trans.png"></a>
+                        <a href="#modalGrasschopper" data-toggle="modal"><img alt="Grasschopper" title="Grasschopper" class="gameObject gameObject-Grasschopper" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGrasschopper" tabindex="-1" role="dialog" aria-labelledby="Grasschopper" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3236,7 +3236,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="bundle of wands" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalBundle-of-Wands" data-toggle="modal"><img alt="Bundle of Wands" title="Bundle of Wands" class="gameObject gameObject-Bundle-of-Wands" src="/img/trans.png"></a>
+                        <a href="#modalBundle-of-Wands" data-toggle="modal"><img alt="Bundle of Wands" title="Bundle of Wands" class="gameObject gameObject-Bundle-of-Wands" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBundle-of-Wands" tabindex="-1" role="dialog" aria-labelledby="Bundle-of-Wands" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3264,7 +3264,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="staff of firepower" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalStaff-of-Firepower" data-toggle="modal"><img alt="Staff of Firepower" title="Staff of Firepower" class="gameObject gameObject-Staff-of-Firepower" src="/img/trans.png"></a>
+                        <a href="#modalStaff-of-Firepower" data-toggle="modal"><img alt="Staff of Firepower" title="Staff of Firepower" class="gameObject gameObject-Staff-of-Firepower" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalStaff-of-Firepower" tabindex="-1" role="dialog" aria-labelledby="Staff-of-Firepower" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3292,7 +3292,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="witch pistol" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalWitch-Pistol" data-toggle="modal"><img alt="Witch Pistol" title="Witch Pistol" class="gameObject gameObject-Witch-Pistol" src="/img/trans.png"></a>
+                        <a href="#modalWitch-Pistol" data-toggle="modal"><img alt="Witch Pistol" title="Witch Pistol" class="gameObject gameObject-Witch-Pistol" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWitch-Pistol" tabindex="-1" role="dialog" aria-labelledby="Witch-Pistol" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3320,7 +3320,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="hexagun" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalHexagun" data-toggle="modal"><img alt="Hexagun" title="Hexagun" class="gameObject gameObject-Hexagun" src="/img/trans.png"></a>
+                        <a href="#modalHexagun" data-toggle="modal"><img alt="Hexagun" title="Hexagun" class="gameObject gameObject-Hexagun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHexagun" tabindex="-1" role="dialog" aria-labelledby="Hexagun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3348,7 +3348,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="phoenix" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalPhoenix" data-toggle="modal"><img alt="Phoenix" title="Phoenix" class="gameObject gameObject-Phoenix" src="/img/trans.png"></a>
+                        <a href="#modalPhoenix" data-toggle="modal"><img alt="Phoenix" title="Phoenix" class="gameObject gameObject-Phoenix" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPhoenix" tabindex="-1" role="dialog" aria-labelledby="Phoenix" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3376,7 +3376,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="magic lamp" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalMagic-Lamp" data-toggle="modal"><img alt="Magic Lamp" title="Magic Lamp" class="gameObject gameObject-Magic-Lamp" src="/img/trans.png"></a>
+                        <a href="#modalMagic-Lamp" data-toggle="modal"><img alt="Magic Lamp" title="Magic Lamp" class="gameObject gameObject-Magic-Lamp" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMagic-Lamp" tabindex="-1" role="dialog" aria-labelledby="Magic-Lamp" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3404,7 +3404,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gunslinger's ashes" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalGunslinger_s-Ashes" data-toggle="modal"><img alt="Gunslinger's Ashes" title="Gunslinger's Ashes" class="gameObject gameObject-Gunslinger_s-Ashes" src="/img/trans.png"></a>
+                        <a href="#modalGunslinger_s-Ashes" data-toggle="modal"><img alt="Gunslinger's Ashes" title="Gunslinger's Ashes" class="gameObject gameObject-Gunslinger_s-Ashes" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunslinger_s-Ashes" tabindex="-1" role="dialog" aria-labelledby="Gunslinger_s-Ashes" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3432,7 +3432,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="luxin cannon" data-quality="4" data-type="Automatic">
-                        <a href="#modalLuxin-Cannon" data-toggle="modal"><img alt="Luxin Cannon" title="Luxin Cannon" class="gameObject gameObject-Luxin-Cannon" src="/img/trans.png"></a>
+                        <a href="#modalLuxin-Cannon" data-toggle="modal"><img alt="Luxin Cannon" title="Luxin Cannon" class="gameObject gameObject-Luxin-Cannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLuxin-Cannon" tabindex="-1" role="dialog" aria-labelledby="Luxin-Cannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3460,7 +3460,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gunther" data-quality="1" data-type="Semiautomatic">
-                        <a href="#modalGunther" data-toggle="modal"><img alt="Gunther" title="Gunther" class="gameObject gameObject-Gunther" src="/img/trans.png"></a>
+                        <a href="#modalGunther" data-toggle="modal"><img alt="Gunther" title="Gunther" class="gameObject gameObject-Gunther" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunther" tabindex="-1" role="dialog" aria-labelledby="Gunther" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3488,7 +3488,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="unicorn horn" data-quality="2" data-type="Beam">
-                        <a href="#modalUnicorn-Horn" data-toggle="modal"><img alt="Unicorn Horn" title="Unicorn Horn" class="gameObject gameObject-Unicorn-Horn" src="/img/trans.png"></a>
+                        <a href="#modalUnicorn-Horn" data-toggle="modal"><img alt="Unicorn Horn" title="Unicorn Horn" class="gameObject gameObject-Unicorn-Horn" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalUnicorn-Horn" tabindex="-1" role="dialog" aria-labelledby="Unicorn-Horn" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3516,7 +3516,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="cobalt hammer" data-quality="2" data-type="Charged">
-                        <a href="#modalCobalt-Hammer" data-toggle="modal"><img alt="Cobalt Hammer" title="Cobalt Hammer" class="gameObject gameObject-Cobalt-Hammer" src="/img/trans.png"></a>
+                        <a href="#modalCobalt-Hammer" data-toggle="modal"><img alt="Cobalt Hammer" title="Cobalt Hammer" class="gameObject gameObject-Cobalt-Hammer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCobalt-Hammer" tabindex="-1" role="dialog" aria-labelledby="Cobalt-Hammer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3544,7 +3544,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="frost giant" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalFrost-Giant" data-toggle="modal"><img alt="Frost Giant" title="Frost Giant" class="gameObject gameObject-Frost-Giant" src="/img/trans.png"></a>
+                        <a href="#modalFrost-Giant" data-toggle="modal"><img alt="Frost Giant" title="Frost Giant" class="gameObject gameObject-Frost-Giant" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFrost-Giant" tabindex="-1" role="dialog" aria-labelledby="Frost-Giant" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3572,7 +3572,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="bullet bore" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalBullet-Bore" data-toggle="modal"><img alt="Bullet Bore" title="Bullet Bore" class="gameObject gameObject-Bullet-Bore" src="/img/trans.png"></a>
+                        <a href="#modalBullet-Bore" data-toggle="modal"><img alt="Bullet Bore" title="Bullet Bore" class="gameObject gameObject-Bullet-Bore" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBullet-Bore" tabindex="-1" role="dialog" aria-labelledby="Bullet-Bore" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3600,7 +3600,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="cat claw" data-quality="2" data-type="Automatic">
-                        <a href="#modalCat-Claw" data-toggle="modal"><img alt="Cat Claw" title="Cat Claw" class="gameObject gameObject-Cat-Claw" src="/img/trans.png"></a>
+                        <a href="#modalCat-Claw" data-toggle="modal"><img alt="Cat Claw" title="Cat Claw" class="gameObject gameObject-Cat-Claw" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCat-Claw" tabindex="-1" role="dialog" aria-labelledby="Cat-Claw" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3628,7 +3628,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="megahand" data-quality="3" data-type="Charged">
-                        <a href="#modalMegahand" data-toggle="modal"><img alt="Megahand" title="Megahand" class="gameObject gameObject-Megahand" src="/img/trans.png"></a>
+                        <a href="#modalMegahand" data-toggle="modal"><img alt="Megahand" title="Megahand" class="gameObject gameObject-Megahand" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMegahand" tabindex="-1" role="dialog" aria-labelledby="Megahand" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3656,7 +3656,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="demon head" data-quality="3" data-type="Beam">
-                        <a href="#modalDemon-Head" data-toggle="modal"><img alt="Demon Head" title="Demon Head" class="gameObject gameObject-Demon-Head" src="/img/trans.png"></a>
+                        <a href="#modalDemon-Head" data-toggle="modal"><img alt="Demon Head" title="Demon Head" class="gameObject gameObject-Demon-Head" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDemon-Head" tabindex="-1" role="dialog" aria-labelledby="Demon-Head" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3684,7 +3684,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="heroine" data-quality="3" data-type="Charged">
-                        <a href="#modalHeroine" data-toggle="modal"><img alt="Heroine" title="Heroine" class="gameObject gameObject-Heroine" src="/img/trans.png"></a>
+                        <a href="#modalHeroine" data-toggle="modal"><img alt="Heroine" title="Heroine" class="gameObject gameObject-Heroine" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeroine" tabindex="-1" role="dialog" aria-labelledby="Heroine" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3712,7 +3712,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="mutation" data-quality="3" data-type="Beam">
-                        <a href="#modalMutation" data-toggle="modal"><img alt="Mutation" title="Mutation" class="gameObject gameObject-Mutation" src="/img/trans.png"></a>
+                        <a href="#modalMutation" data-toggle="modal"><img alt="Mutation" title="Mutation" class="gameObject gameObject-Mutation" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMutation" tabindex="-1" role="dialog" aria-labelledby="Mutation" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3740,7 +3740,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="flame hand" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalFlame-Hand" data-toggle="modal"><img alt="Flame Hand" title="Flame Hand" class="gameObject gameObject-Flame-Hand" src="/img/trans.png"></a>
+                        <a href="#modalFlame-Hand" data-toggle="modal"><img alt="Flame Hand" title="Flame Hand" class="gameObject gameObject-Flame-Hand" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFlame-Hand" tabindex="-1" role="dialog" aria-labelledby="Flame-Hand" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3768,7 +3768,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="machine fist" data-quality="2" data-type="Automatic">
-                        <a href="#modalMachine-Fist" data-toggle="modal"><img alt="Machine Fist" title="Machine Fist" class="gameObject gameObject-Machine-Fist" src="/img/trans.png"></a>
+                        <a href="#modalMachine-Fist" data-toggle="modal"><img alt="Machine Fist" title="Machine Fist" class="gameObject gameObject-Machine-Fist" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMachine-Fist" tabindex="-1" role="dialog" aria-labelledby="Machine-Fist" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3796,7 +3796,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="snowballer" data-quality="5" data-type="Automatic">
-                        <a href="#modalSnowballer" data-toggle="modal"><img alt="Snowballer" title="Snowballer" class="gameObject gameObject-Snowballer" src="/img/trans.png"></a>
+                        <a href="#modalSnowballer" data-toggle="modal"><img alt="Snowballer" title="Snowballer" class="gameObject gameObject-Snowballer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSnowballer" tabindex="-1" role="dialog" aria-labelledby="Snowballer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3824,7 +3824,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="super meat gun" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalSuper-Meat-Gun" data-toggle="modal"><img alt="Super Meat Gun" title="Super Meat Gun" class="gameObject gameObject-Super-Meat-Gun" src="/img/trans.png"></a>
+                        <a href="#modalSuper-Meat-Gun" data-toggle="modal"><img alt="Super Meat Gun" title="Super Meat Gun" class="gameObject gameObject-Super-Meat-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSuper-Meat-Gun" tabindex="-1" role="dialog" aria-labelledby="Super-Meat-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3852,7 +3852,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="anvillain" data-quality="4" data-type="Charged">
-                        <a href="#modalAnvillain" data-toggle="modal"><img alt="Anvillain" title="Anvillain" class="gameObject gameObject-Anvillain" src="/img/trans.png"></a>
+                        <a href="#modalAnvillain" data-toggle="modal"><img alt="Anvillain" title="Anvillain" class="gameObject gameObject-Anvillain" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAnvillain" tabindex="-1" role="dialog" aria-labelledby="Anvillain" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3880,7 +3880,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="fossilized gun" data-quality="5" data-type="Beam">
-                        <a href="#modalFossilized-Gun" data-toggle="modal"><img alt="Fossilized Gun" title="Fossilized Gun" class="gameObject gameObject-Fossilized-Gun" src="/img/trans.png"></a>
+                        <a href="#modalFossilized-Gun" data-toggle="modal"><img alt="Fossilized Gun" title="Fossilized Gun" class="gameObject gameObject-Fossilized-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFossilized-Gun" tabindex="-1" role="dialog" aria-labelledby="Fossilized-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3908,7 +3908,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gamma ray" data-quality="4" data-type="Beam">
-                        <a href="#modalGamma-Ray" data-toggle="modal"><img alt="Gamma Ray" title="Gamma Ray" class="gameObject gameObject-Gamma-Ray" src="/img/trans.png"></a>
+                        <a href="#modalGamma-Ray" data-toggle="modal"><img alt="Gamma Ray" title="Gamma Ray" class="gameObject gameObject-Gamma-Ray" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGamma-Ray" tabindex="-1" role="dialog" aria-labelledby="Gamma-Ray" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3936,7 +3936,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="freeze ray" data-quality="2" data-type="Beam">
-                        <a href="#modalFreeze-Ray" data-toggle="modal"><img alt="Freeze Ray" title="Freeze Ray" class="gameObject gameObject-Freeze-Ray" src="/img/trans.png"></a>
+                        <a href="#modalFreeze-Ray" data-toggle="modal"><img alt="Freeze Ray" title="Freeze Ray" class="gameObject gameObject-Freeze-Ray" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFreeze-Ray" tabindex="-1" role="dialog" aria-labelledby="Freeze-Ray" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3964,7 +3964,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="science cannon" data-quality="3" data-type="Beam">
-                        <a href="#modalScience-Cannon" data-toggle="modal"><img alt="Science Cannon" title="Science Cannon" class="gameObject gameObject-Science-Cannon" src="/img/trans.png"></a>
+                        <a href="#modalScience-Cannon" data-toggle="modal"><img alt="Science Cannon" title="Science Cannon" class="gameObject gameObject-Science-Cannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalScience-Cannon" tabindex="-1" role="dialog" aria-labelledby="Science-Cannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -3992,7 +3992,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="disintegrator" data-quality="1" data-type="Beam">
-                        <a href="#modalDisintegrator" data-toggle="modal"><img alt="Disintegrator" title="Disintegrator" class="gameObject gameObject-Disintegrator" src="/img/trans.png"></a>
+                        <a href="#modalDisintegrator" data-toggle="modal"><img alt="Disintegrator" title="Disintegrator" class="gameObject gameObject-Disintegrator" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDisintegrator" tabindex="-1" role="dialog" aria-labelledby="Disintegrator" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4020,7 +4020,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="proton backpack" data-quality="3" data-type="Beam">
-                        <a href="#modalProton-Backpack" data-toggle="modal"><img alt="Proton Backpack" title="Proton Backpack" class="gameObject gameObject-Proton-Backpack" src="/img/trans.png"></a>
+                        <a href="#modalProton-Backpack" data-toggle="modal"><img alt="Proton Backpack" title="Proton Backpack" class="gameObject gameObject-Proton-Backpack" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalProton-Backpack" tabindex="-1" role="dialog" aria-labelledby="Proton-Backpack" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4048,7 +4048,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="mega douser" data-quality="5" data-type="Beam">
-                        <a href="#modalMega-Douser" data-toggle="modal"><img alt="Mega Douser" title="Mega Douser" class="gameObject gameObject-Mega-Douser" src="/img/trans.png"></a>
+                        <a href="#modalMega-Douser" data-toggle="modal"><img alt="Mega Douser" title="Mega Douser" class="gameObject gameObject-Mega-Douser" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMega-Douser" tabindex="-1" role="dialog" aria-labelledby="Mega-Douser" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4076,7 +4076,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="plunger" data-quality="4" data-type="Beam">
-                        <a href="#modalPlunger" data-toggle="modal"><img alt="Plunger" title="Plunger" class="gameObject gameObject-Plunger" src="/img/trans.png"></a>
+                        <a href="#modalPlunger" data-toggle="modal"><img alt="Plunger" title="Plunger" class="gameObject gameObject-Plunger" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPlunger" tabindex="-1" role="dialog" aria-labelledby="Plunger" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4104,7 +4104,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="raiden coil" data-quality="2" data-type="Beam">
-                        <a href="#modalRaiden-Coil" data-toggle="modal"><img alt="Raiden Coil" title="Raiden Coil" class="gameObject gameObject-Raiden-Coil" src="/img/trans.png"></a>
+                        <a href="#modalRaiden-Coil" data-toggle="modal"><img alt="Raiden Coil" title="Raiden Coil" class="gameObject gameObject-Raiden-Coil" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRaiden-Coil" tabindex="-1" role="dialog" aria-labelledby="Raiden-Coil" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4132,7 +4132,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="moonscraper" data-quality="4" data-type="Beam">
-                        <a href="#modalMoonscraper" data-toggle="modal"><img alt="Moonscraper" title="Moonscraper" class="gameObject gameObject-Moonscraper" src="/img/trans.png"></a>
+                        <a href="#modalMoonscraper" data-toggle="modal"><img alt="Moonscraper" title="Moonscraper" class="gameObject gameObject-Moonscraper" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMoonscraper" tabindex="-1" role="dialog" aria-labelledby="Moonscraper" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4160,7 +4160,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="barrel" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalBarrel" data-toggle="modal"><img alt="Barrel" title="Barrel" class="gameObject gameObject-Barrel" src="/img/trans.png"></a>
+                        <a href="#modalBarrel" data-toggle="modal"><img alt="Barrel" title="Barrel" class="gameObject gameObject-Barrel" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBarrel" tabindex="-1" role="dialog" aria-labelledby="Barrel" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4188,7 +4188,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="trick gun" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalTrick-Gun" data-toggle="modal"><img alt="Trick Gun" title="Trick Gun" class="gameObject gameObject-Trick-Gun" src="/img/trans.png"></a>
+                        <a href="#modalTrick-Gun" data-toggle="modal"><img alt="Trick Gun" title="Trick Gun" class="gameObject gameObject-Trick-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTrick-Gun" tabindex="-1" role="dialog" aria-labelledby="Trick-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4216,7 +4216,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="mailbox" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalMailbox" data-toggle="modal"><img alt="Mailbox" title="Mailbox" class="gameObject gameObject-Mailbox" src="/img/trans.png"></a>
+                        <a href="#modalMailbox" data-toggle="modal"><img alt="Mailbox" title="Mailbox" class="gameObject gameObject-Mailbox" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMailbox" tabindex="-1" role="dialog" aria-labelledby="Mailbox" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4244,7 +4244,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="nail gun" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalNail-Gun" data-toggle="modal"><img alt="Nail Gun" title="Nail Gun" class="gameObject gameObject-Nail-Gun" src="/img/trans.png"></a>
+                        <a href="#modalNail-Gun" data-toggle="modal"><img alt="Nail Gun" title="Nail Gun" class="gameObject gameObject-Nail-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalNail-Gun" tabindex="-1" role="dialog" aria-labelledby="Nail-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4272,7 +4272,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="light gun" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalLight-Gun" data-toggle="modal"><img alt="Light Gun" title="Light Gun" class="gameObject gameObject-Light-Gun" src="/img/trans.png"></a>
+                        <a href="#modalLight-Gun" data-toggle="modal"><img alt="Light Gun" title="Light Gun" class="gameObject gameObject-Light-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLight-Gun" tabindex="-1" role="dialog" aria-labelledby="Light-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4300,7 +4300,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="mahoguny" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalMahoguny" data-toggle="modal"><img alt="Mahoguny" title="Mahoguny" class="gameObject gameObject-Mahoguny" src="/img/trans.png"></a>
+                        <a href="#modalMahoguny" data-toggle="modal"><img alt="Mahoguny" title="Mahoguny" class="gameObject gameObject-Mahoguny" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMahoguny" tabindex="-1" role="dialog" aria-labelledby="Mahoguny" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4328,7 +4328,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="the scrambler" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalThe-Scrambler" data-toggle="modal"><img alt="The Scrambler" title="The Scrambler" class="gameObject gameObject-The-Scrambler" src="/img/trans.png"></a>
+                        <a href="#modalThe-Scrambler" data-toggle="modal"><img alt="The Scrambler" title="The Scrambler" class="gameObject gameObject-The-Scrambler" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalThe-Scrambler" tabindex="-1" role="dialog" aria-labelledby="The-Scrambler" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4356,7 +4356,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="trashcannon" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalTrashcannon" data-toggle="modal"><img alt="Trashcannon" title="Trashcannon" class="gameObject gameObject-Trashcannon" src="/img/trans.png"></a>
+                        <a href="#modalTrashcannon" data-toggle="modal"><img alt="Trashcannon" title="Trashcannon" class="gameObject gameObject-Trashcannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTrashcannon" tabindex="-1" role="dialog" aria-labelledby="Trashcannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4384,7 +4384,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="glacier" data-quality="4" data-type="Automatic">
-                        <a href="#modalGlacier" data-toggle="modal"><img alt="Glacier" title="Glacier" class="gameObject gameObject-Glacier" src="/img/trans.png"></a>
+                        <a href="#modalGlacier" data-toggle="modal"><img alt="Glacier" title="Glacier" class="gameObject gameObject-Glacier" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGlacier" tabindex="-1" role="dialog" aria-labelledby="Glacier" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4412,7 +4412,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="origuni" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalOriguni" data-toggle="modal"><img alt="Origuni" title="Origuni" class="gameObject gameObject-Origuni" src="/img/trans.png"></a>
+                        <a href="#modalOriguni" data-toggle="modal"><img alt="Origuni" title="Origuni" class="gameObject gameObject-Origuni" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOriguni" tabindex="-1" role="dialog" aria-labelledby="Origuni" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4440,7 +4440,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="the kiln" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalThe-Kiln" data-toggle="modal"><img alt="The Kiln" title="The Kiln" class="gameObject gameObject-The-Kiln" src="/img/trans.png"></a>
+                        <a href="#modalThe-Kiln" data-toggle="modal"><img alt="The Kiln" title="The Kiln" class="gameObject gameObject-The-Kiln" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalThe-Kiln" tabindex="-1" role="dialog" aria-labelledby="The-Kiln" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4468,7 +4468,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="skull spitter" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalSkull-Spitter" data-toggle="modal"><img alt="Skull Spitter" title="Skull Spitter" class="gameObject gameObject-Skull-Spitter" src="/img/trans.png"></a>
+                        <a href="#modalSkull-Spitter" data-toggle="modal"><img alt="Skull Spitter" title="Skull Spitter" class="gameObject gameObject-Skull-Spitter" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSkull-Spitter" tabindex="-1" role="dialog" aria-labelledby="Skull-Spitter" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4496,7 +4496,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="buzzkill" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalBuzzkill" data-toggle="modal"><img alt="Buzzkill" title="Buzzkill" class="gameObject gameObject-Buzzkill" src="/img/trans.png"></a>
+                        <a href="#modalBuzzkill" data-toggle="modal"><img alt="Buzzkill" title="Buzzkill" class="gameObject gameObject-Buzzkill" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBuzzkill" tabindex="-1" role="dialog" aria-labelledby="Buzzkill" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4524,7 +4524,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="tear jerker" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalTear-Jerker" data-toggle="modal"><img alt="Tear Jerker" title="Tear Jerker" class="gameObject gameObject-Tear-Jerker" src="/img/trans.png"></a>
+                        <a href="#modalTear-Jerker" data-toggle="modal"><img alt="Tear Jerker" title="Tear Jerker" class="gameObject gameObject-Tear-Jerker" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTear-Jerker" tabindex="-1" role="dialog" aria-labelledby="Tear-Jerker" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4552,7 +4552,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="eye of the beholster" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalEye-of-the-Beholster" data-toggle="modal"><img alt="Eye of the Beholster" title="Eye of the Beholster" class="gameObject gameObject-Eye-of-the-Beholster" src="/img/trans.png"></a>
+                        <a href="#modalEye-of-the-Beholster" data-toggle="modal"><img alt="Eye of the Beholster" title="Eye of the Beholster" class="gameObject gameObject-Eye-of-the-Beholster" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalEye-of-the-Beholster" tabindex="-1" role="dialog" aria-labelledby="Eye-of-the-Beholster" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4580,7 +4580,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="molotov launcher" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalMolotov-Launcher" data-toggle="modal"><img alt="Molotov Launcher" title="Molotov Launcher" class="gameObject gameObject-Molotov-Launcher" src="/img/trans.png"></a>
+                        <a href="#modalMolotov-Launcher" data-toggle="modal"><img alt="Molotov Launcher" title="Molotov Launcher" class="gameObject gameObject-Molotov-Launcher" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMolotov-Launcher" tabindex="-1" role="dialog" aria-labelledby="Molotov-Launcher" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4608,7 +4608,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="shock rifle" data-quality="3" data-type="Semiautomatic">
-                        <a href="#modalShock-Rifle" data-toggle="modal"><img alt="Shock Rifle" title="Shock Rifle" class="gameObject gameObject-Shock-Rifle" src="/img/trans.png"></a>
+                        <a href="#modalShock-Rifle" data-toggle="modal"><img alt="Shock Rifle" title="Shock Rifle" class="gameObject gameObject-Shock-Rifle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShock-Rifle" tabindex="-1" role="dialog" aria-labelledby="Shock-Rifle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4636,7 +4636,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="bait launcher" data-quality="4" data-type="Charged">
-                        <a href="#modalBait-Launcher" data-toggle="modal"><img alt="Bait Launcher" title="Bait Launcher" class="gameObject gameObject-Bait-Launcher" src="/img/trans.png"></a>
+                        <a href="#modalBait-Launcher" data-toggle="modal"><img alt="Bait Launcher" title="Bait Launcher" class="gameObject gameObject-Bait-Launcher" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBait-Launcher" tabindex="-1" role="dialog" aria-labelledby="Bait-Launcher" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4664,7 +4664,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="brick breaker" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalBrick-Breaker" data-toggle="modal"><img alt="Brick Breaker" title="Brick Breaker" class="gameObject gameObject-Brick-Breaker" src="/img/trans.png"></a>
+                        <a href="#modalBrick-Breaker" data-toggle="modal"><img alt="Brick Breaker" title="Brick Breaker" class="gameObject gameObject-Brick-Breaker" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBrick-Breaker" tabindex="-1" role="dialog" aria-labelledby="Brick-Breaker" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4692,7 +4692,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="betrayer's shield" data-quality="3" data-type="Automatic">
-                        <a href="#modalBetrayer_s-Shield" data-toggle="modal"><img alt="Betrayer's Shield" title="Betrayer's Shield" class="gameObject gameObject-Betrayer_s-Shield" src="/img/trans.png"></a>
+                        <a href="#modalBetrayer_s-Shield" data-toggle="modal"><img alt="Betrayer's Shield" title="Betrayer's Shield" class="gameObject gameObject-Betrayer_s-Shield" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBetrayer_s-Shield" tabindex="-1" role="dialog" aria-labelledby="Betrayer_s-Shield" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4720,7 +4720,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="lower case r" data-quality="5" data-type="Burst">
-                        <a href="#modalLower-Case-r" data-toggle="modal"><img alt="Lower Case r" title="Lower Case r" class="gameObject gameObject-Lower-Case-r" src="/img/trans.png"></a>
+                        <a href="#modalLower-Case-r" data-toggle="modal"><img alt="Lower Case r" title="Lower Case r" class="gameObject gameObject-Lower-Case-r" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLower-Case-r" tabindex="-1" role="dialog" aria-labelledby="Lower-Case-r" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4748,7 +4748,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="excaliber" data-quality="3" data-type="Burst">
-                        <a href="#modalExcaliber" data-toggle="modal"><img alt="Excaliber" title="Excaliber" class="gameObject gameObject-Excaliber" src="/img/trans.png"></a>
+                        <a href="#modalExcaliber" data-toggle="modal"><img alt="Excaliber" title="Excaliber" class="gameObject gameObject-Excaliber" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalExcaliber" tabindex="-1" role="dialog" aria-labelledby="Excaliber" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4776,7 +4776,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="face melter" data-quality="3" data-type="Automatic">
-                        <a href="#modalFace-Melter" data-toggle="modal"><img alt="Face Melter" title="Face Melter" class="gameObject gameObject-Face-Melter" src="/img/trans.png"></a>
+                        <a href="#modalFace-Melter" data-toggle="modal"><img alt="Face Melter" title="Face Melter" class="gameObject gameObject-Face-Melter" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFace-Melter" tabindex="-1" role="dialog" aria-labelledby="Face-Melter" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4804,7 +4804,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="trident" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalTrident" data-toggle="modal"><img alt="Trident" title="Trident" class="gameObject gameObject-Trident" src="/img/trans.png"></a>
+                        <a href="#modalTrident" data-toggle="modal"><img alt="Trident" title="Trident" class="gameObject gameObject-Trident" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTrident" tabindex="-1" role="dialog" aria-labelledby="Trident" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4832,7 +4832,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="abyssal tentacle" data-quality="2" data-type="Beam">
-                        <a href="#modalAbyssal-Tentacle" data-toggle="modal"><img alt="Abyssal Tentacle" title="Abyssal Tentacle" class="gameObject gameObject-Abyssal-Tentacle" src="/img/trans.png"></a>
+                        <a href="#modalAbyssal-Tentacle" data-toggle="modal"><img alt="Abyssal Tentacle" title="Abyssal Tentacle" class="gameObject gameObject-Abyssal-Tentacle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAbyssal-Tentacle" tabindex="-1" role="dialog" aria-labelledby="Abyssal-Tentacle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4860,7 +4860,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="quad laser" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalQuad-Laser" data-toggle="modal"><img alt="Quad Laser" title="Quad Laser" class="gameObject gameObject-Quad-Laser" src="/img/trans.png"></a>
+                        <a href="#modalQuad-Laser" data-toggle="modal"><img alt="Quad Laser" title="Quad Laser" class="gameObject gameObject-Quad-Laser" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalQuad-Laser" tabindex="-1" role="dialog" aria-labelledby="Quad-Laser" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4888,7 +4888,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="pitchfork" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalPitchfork" data-toggle="modal"><img alt="Pitchfork" title="Pitchfork" class="gameObject gameObject-Pitchfork" src="/img/trans.png"></a>
+                        <a href="#modalPitchfork" data-toggle="modal"><img alt="Pitchfork" title="Pitchfork" class="gameObject gameObject-Pitchfork" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPitchfork" tabindex="-1" role="dialog" aria-labelledby="Pitchfork" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4916,7 +4916,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gungeon ant" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalGungeon-Ant" data-toggle="modal"><img alt="Gungeon Ant" title="Gungeon Ant" class="gameObject gameObject-Gungeon-Ant" src="/img/trans.png"></a>
+                        <a href="#modalGungeon-Ant" data-toggle="modal"><img alt="Gungeon Ant" title="Gungeon Ant" class="gameObject gameObject-Gungeon-Ant" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGungeon-Ant" tabindex="-1" role="dialog" aria-labelledby="Gungeon-Ant" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4944,7 +4944,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="alien engine" data-quality="3" data-type="Automatic">
-                        <a href="#modalAlien-Engine" data-toggle="modal"><img alt="Alien Engine" title="Alien Engine" class="gameObject gameObject-Alien-Engine" src="/img/trans.png"></a>
+                        <a href="#modalAlien-Engine" data-toggle="modal"><img alt="Alien Engine" title="Alien Engine" class="gameObject gameObject-Alien-Engine" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAlien-Engine" tabindex="-1" role="dialog" aria-labelledby="Alien-Engine" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -4972,7 +4972,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="microtransaction gun" data-quality="2" data-type="Semiautomatic">
-                        <a href="#modalMicrotransaction-Gun" data-toggle="modal"><img alt="Microtransaction Gun" title="Microtransaction Gun" class="gameObject gameObject-Microtransaction-Gun" src="/img/trans.png"></a>
+                        <a href="#modalMicrotransaction-Gun" data-toggle="modal"><img alt="Microtransaction Gun" title="Microtransaction Gun" class="gameObject gameObject-Microtransaction-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMicrotransaction-Gun" tabindex="-1" role="dialog" aria-labelledby="Microtransaction-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5000,7 +5000,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="poxcannon" data-quality="4" data-type="">
-                        <a href="#modalPoxcannon" data-toggle="modal"><img alt="Poxcannon" title="Poxcannon" class="gameObject gameObject-Poxcannon" src="/img/trans.png"></a>
+                        <a href="#modalPoxcannon" data-toggle="modal"><img alt="Poxcannon" title="Poxcannon" class="gameObject gameObject-Poxcannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPoxcannon" tabindex="-1" role="dialog" aria-labelledby="Poxcannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5028,7 +5028,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="t-shirt cannon" data-quality="5" data-type="Semiautomatic">
-                        <a href="#modalT-Shirt-Cannon" data-toggle="modal"><img alt="T-Shirt Cannon" title="T-Shirt Cannon" class="gameObject gameObject-T-Shirt-Cannon" src="/img/trans.png"></a>
+                        <a href="#modalT-Shirt-Cannon" data-toggle="modal"><img alt="T-Shirt Cannon" title="T-Shirt Cannon" class="gameObject gameObject-T-Shirt-Cannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalT-Shirt-Cannon" tabindex="-1" role="dialog" aria-labelledby="T-Shirt-Cannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5056,7 +5056,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="banana" data-quality="4" data-type="Charged">
-                        <a href="#modalBanana" data-toggle="modal"><img alt="Banana" title="Banana" class="gameObject gameObject-Banana" src="/img/trans.png"></a>
+                        <a href="#modalBanana" data-toggle="modal"><img alt="Banana" title="Banana" class="gameObject gameObject-Banana" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBanana" tabindex="-1" role="dialog" aria-labelledby="Banana" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5084,7 +5084,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="bee hive" data-quality="3" data-type="Automatic">
-                        <a href="#modalBee-Hive" data-toggle="modal"><img alt="Bee Hive" title="Bee Hive" class="gameObject gameObject-Bee-Hive" src="/img/trans.png"></a>
+                        <a href="#modalBee-Hive" data-toggle="modal"><img alt="Bee Hive" title="Bee Hive" class="gameObject gameObject-Bee-Hive" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBee-Hive" tabindex="-1" role="dialog" aria-labelledby="Bee-Hive" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5112,7 +5112,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="silencer" data-quality="4" data-type="Semiautomatic">
-                        <a href="#modalSilencer" data-toggle="modal"><img alt="Silencer" title="Silencer" class="gameObject gameObject-Silencer" src="/img/trans.png"></a>
+                        <a href="#modalSilencer" data-toggle="modal"><img alt="Silencer" title="Silencer" class="gameObject gameObject-Silencer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSilencer" tabindex="-1" role="dialog" aria-labelledby="Silencer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5140,7 +5140,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="camera" data-quality="4" data-type="Charged">
-                        <a href="#modalCamera" data-toggle="modal"><img alt="Camera" title="Camera" class="gameObject gameObject-Camera" src="/img/trans.png"></a>
+                        <a href="#modalCamera" data-toggle="modal"><img alt="Camera" title="Camera" class="gameObject gameObject-Camera" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCamera" tabindex="-1" role="dialog" aria-labelledby="Camera" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5168,7 +5168,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="gunzheng" data-quality="3" data-type="Automatic">
-                        <a href="#modalGunzheng" data-toggle="modal"><img alt="Gunzheng" title="Gunzheng" class="gameObject gameObject-Gunzheng" src="/img/trans.png"></a>
+                        <a href="#modalGunzheng" data-toggle="modal"><img alt="Gunzheng" title="Gunzheng" class="gameObject gameObject-Gunzheng" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunzheng" tabindex="-1" role="dialog" aria-labelledby="Gunzheng" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5196,7 +5196,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="sling" data-quality="5" data-type="Charged">
-                        <a href="#modalSling" data-toggle="modal"><img alt="Sling" title="Sling" class="gameObject gameObject-Sling" src="/img/trans.png"></a>
+                        <a href="#modalSling" data-toggle="modal"><img alt="Sling" title="Sling" class="gameObject gameObject-Sling" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSling" tabindex="-1" role="dialog" aria-labelledby="Sling" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5224,7 +5224,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="cactus" data-quality="4" data-type="Automatic">
-                        <a href="#modalCactus" data-toggle="modal"><img alt="Cactus" title="Cactus" class="gameObject gameObject-Cactus" src="/img/trans.png"></a>
+                        <a href="#modalCactus" data-toggle="modal"><img alt="Cactus" title="Cactus" class="gameObject gameObject-Cactus" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCactus" tabindex="-1" role="dialog" aria-labelledby="Cactus" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5252,7 +5252,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="black hole gun" data-quality="1" data-type="Charged">
-                        <a href="#modalBlack-Hole-Gun" data-toggle="modal"><img alt="Black Hole Gun" title="Black Hole Gun" class="gameObject gameObject-Black-Hole-Gun" src="/img/trans.png"></a>
+                        <a href="#modalBlack-Hole-Gun" data-toggle="modal"><img alt="Black Hole Gun" title="Black Hole Gun" class="gameObject gameObject-Black-Hole-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlack-Hole-Gun" tabindex="-1" role="dialog" aria-labelledby="Black-Hole-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5280,7 +5280,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="bsg" data-quality="1" data-type="Charged">
-                        <a href="#modalBSG" data-toggle="modal"><img alt="BSG" title="BSG" class="gameObject gameObject-BSG" src="/img/trans.png"></a>
+                        <a href="#modalBSG" data-toggle="modal"><img alt="BSG" title="BSG" class="gameObject gameObject-BSG" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBSG" tabindex="-1" role="dialog" aria-labelledby="BSG" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5308,7 +5308,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="compressed air tank" data-quality="2" data-type="Charged">
-                        <a href="#modalCompressed-Air-Tank" data-toggle="modal"><img alt="Compressed Air Tank" title="Compressed Air Tank" class="gameObject gameObject-Compressed-Air-Tank" src="/img/trans.png"></a>
+                        <a href="#modalCompressed-Air-Tank" data-toggle="modal"><img alt="Compressed Air Tank" title="Compressed Air Tank" class="gameObject gameObject-Compressed-Air-Tank" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCompressed-Air-Tank" tabindex="-1" role="dialog" aria-labelledby="Compressed-Air-Tank" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5336,7 +5336,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="serious cannon" data-quality="2" data-type="Charged">
-                        <a href="#modalSerious-Cannon" data-toggle="modal"><img alt="Serious Cannon" title="Serious Cannon" class="gameObject gameObject-Serious-Cannon" src="/img/trans.png"></a>
+                        <a href="#modalSerious-Cannon" data-toggle="modal"><img alt="Serious Cannon" title="Serious Cannon" class="gameObject gameObject-Serious-Cannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSerious-Cannon" tabindex="-1" role="dialog" aria-labelledby="Serious-Cannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5364,7 +5364,7 @@
                         </div>
                     </div>
                     <div class="grid-item1" data-name="makeshift cannon" data-quality="1" data-type="Charged">
-                        <a href="#modalMakeshift-Cannon" data-toggle="modal"><img alt="Makeshift Cannon" title="Makeshift Cannon" class="gameObject gameObject-Makeshift-Cannon" src="/img/trans.png"></a>
+                        <a href="#modalMakeshift-Cannon" data-toggle="modal"><img alt="Makeshift Cannon" title="Makeshift Cannon" class="gameObject gameObject-Makeshift-Cannon" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMakeshift-Cannon" tabindex="-1" role="dialog" aria-labelledby="Makeshift-Cannon" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5395,7 +5395,7 @@
                 <h1 class="page-header">Items</h1>
                 <div class="grid2" id="items">
                     <div class="grid-item2" data-name="master round i" data-quality="6" data-type="Passive">
-                        <a href="#modalMaster-Round-I" data-toggle="modal"><img alt="Master Round I" title="Master Round I" class="gameObject gameObject-Master-Round-I" src="/img/trans.png"></a>
+                        <a href="#modalMaster-Round-I" data-toggle="modal"><img alt="Master Round I" title="Master Round I" class="gameObject gameObject-Master-Round-I" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMaster-Round-I" tabindex="-1" role="dialog" aria-labelledby="Master-Round-I" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5415,7 +5415,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="master round ii" data-quality="6" data-type="Passive">
-                        <a href="#modalMaster-Round-II" data-toggle="modal"><img alt="Master Round II" title="Master Round II" class="gameObject gameObject-Master-Round-II" src="/img/trans.png"></a>
+                        <a href="#modalMaster-Round-II" data-toggle="modal"><img alt="Master Round II" title="Master Round II" class="gameObject gameObject-Master-Round-II" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMaster-Round-II" tabindex="-1" role="dialog" aria-labelledby="Master-Round-II" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5435,7 +5435,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="master round iii" data-quality="6" data-type="Passive">
-                        <a href="#modalMaster-Round-III" data-toggle="modal"><img alt="Master Round III" title="Master Round III" class="gameObject gameObject-Master-Round-III" src="/img/trans.png"></a>
+                        <a href="#modalMaster-Round-III" data-toggle="modal"><img alt="Master Round III" title="Master Round III" class="gameObject gameObject-Master-Round-III" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMaster-Round-III" tabindex="-1" role="dialog" aria-labelledby="Master-Round-III" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5455,7 +5455,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="master round iv" data-quality="6" data-type="Passive">
-                        <a href="#modalMaster-Round-IV" data-toggle="modal"><img alt="Master Round IV" title="Master Round IV" class="gameObject gameObject-Master-Round-IV" src="/img/trans.png"></a>
+                        <a href="#modalMaster-Round-IV" data-toggle="modal"><img alt="Master Round IV" title="Master Round IV" class="gameObject gameObject-Master-Round-IV" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMaster-Round-IV" tabindex="-1" role="dialog" aria-labelledby="Master-Round-IV" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5475,7 +5475,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="master round v" data-quality="6" data-type="Passive">
-                        <a href="#modalMaster-Round-V" data-toggle="modal"><img alt="Master Round V" title="Master Round V" class="gameObject gameObject-Master-Round-V" src="/img/trans.png"></a>
+                        <a href="#modalMaster-Round-V" data-toggle="modal"><img alt="Master Round V" title="Master Round V" class="gameObject gameObject-Master-Round-V" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMaster-Round-V" tabindex="-1" role="dialog" aria-labelledby="Master-Round-V" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5495,7 +5495,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="prime primer" data-quality="6" data-type="Passive">
-                        <a href="#modalPrime-Primer" data-toggle="modal"><img alt="Prime Primer" title="Prime Primer" class="gameObject gameObject-Prime-Primer" src="/img/trans.png"></a>
+                        <a href="#modalPrime-Primer" data-toggle="modal"><img alt="Prime Primer" title="Prime Primer" class="gameObject gameObject-Prime-Primer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPrime-Primer" tabindex="-1" role="dialog" aria-labelledby="Prime-Primer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5515,7 +5515,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="arcane gunpowder" data-quality="6" data-type="Active">
-                        <a href="#modalArcane-Gunpowder" data-toggle="modal"><img alt="Arcane Gunpowder" title="Arcane Gunpowder" class="gameObject gameObject-Arcane-Gunpowder" src="/img/trans.png"></a>
+                        <a href="#modalArcane-Gunpowder" data-toggle="modal"><img alt="Arcane Gunpowder" title="Arcane Gunpowder" class="gameObject gameObject-Arcane-Gunpowder" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalArcane-Gunpowder" tabindex="-1" role="dialog" aria-labelledby="Arcane-Gunpowder" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5535,7 +5535,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="planar lead" data-quality="6" data-type="Passive">
-                        <a href="#modalPlanar-Lead" data-toggle="modal"><img alt="Planar Lead" title="Planar Lead" class="gameObject gameObject-Planar-Lead" src="/img/trans.png"></a>
+                        <a href="#modalPlanar-Lead" data-toggle="modal"><img alt="Planar Lead" title="Planar Lead" class="gameObject gameObject-Planar-Lead" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPlanar-Lead" tabindex="-1" role="dialog" aria-labelledby="Planar-Lead" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5555,7 +5555,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="obsidian shell casing" data-quality="6" data-type="Passive">
-                        <a href="#modalObsidian-Shell-Casing" data-toggle="modal"><img alt="Obsidian Shell Casing" title="Obsidian Shell Casing" class="gameObject gameObject-Obsidian-Shell-Casing" src="/img/trans.png"></a>
+                        <a href="#modalObsidian-Shell-Casing" data-toggle="modal"><img alt="Obsidian Shell Casing" title="Obsidian Shell Casing" class="gameObject gameObject-Obsidian-Shell-Casing" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalObsidian-Shell-Casing" tabindex="-1" role="dialog" aria-labelledby="Obsidian-Shell-Casing" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5575,7 +5575,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="meatbun" data-quality="5" data-type="Active">
-                        <a href="#modalMeatbun" data-toggle="modal"><img alt="Meatbun" title="Meatbun" class="gameObject gameObject-Meatbun" src="/img/trans.png"></a>
+                        <a href="#modalMeatbun" data-toggle="modal"><img alt="Meatbun" title="Meatbun" class="gameObject gameObject-Meatbun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMeatbun" tabindex="-1" role="dialog" aria-labelledby="Meatbun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5595,7 +5595,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="medkit" data-quality="4" data-type="Active">
-                        <a href="#modalMedkit" data-toggle="modal"><img alt="Medkit" title="Medkit" class="gameObject gameObject-Medkit" src="/img/trans.png"></a>
+                        <a href="#modalMedkit" data-toggle="modal"><img alt="Medkit" title="Medkit" class="gameObject gameObject-Medkit" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMedkit" tabindex="-1" role="dialog" aria-labelledby="Medkit" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5615,7 +5615,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ration" data-quality="2" data-type="Active">
-                        <a href="#modalRation" data-toggle="modal"><img alt="Ration" title="Ration" class="gameObject gameObject-Ration" src="/img/trans.png"></a>
+                        <a href="#modalRation" data-toggle="modal"><img alt="Ration" title="Ration" class="gameObject gameObject-Ration" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRation" tabindex="-1" role="dialog" aria-labelledby="Ration" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5635,7 +5635,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="orange" data-quality="4" data-type="Active">
-                        <a href="#modalOrange" data-toggle="modal"><img alt="Orange" title="Orange" class="gameObject gameObject-Orange" src="/img/trans.png"></a>
+                        <a href="#modalOrange" data-toggle="modal"><img alt="Orange" title="Orange" class="gameObject gameObject-Orange" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOrange" tabindex="-1" role="dialog" aria-labelledby="Orange" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5655,7 +5655,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="friendship cookie" data-quality="6" data-type="Active">
-                        <a href="#modalFriendship-Cookie" data-toggle="modal"><img alt="Friendship Cookie" title="Friendship Cookie" class="gameObject gameObject-Friendship-Cookie" src="/img/trans.png"></a>
+                        <a href="#modalFriendship-Cookie" data-toggle="modal"><img alt="Friendship Cookie" title="Friendship Cookie" class="gameObject gameObject-Friendship-Cookie" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFriendship-Cookie" tabindex="-1" role="dialog" aria-labelledby="Friendship-Cookie" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5675,7 +5675,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bomb" data-quality="5" data-type="Active">
-                        <a href="#modalBomb" data-toggle="modal"><img alt="Bomb" title="Bomb" class="gameObject gameObject-Bomb" src="/img/trans.png"></a>
+                        <a href="#modalBomb" data-toggle="modal"><img alt="Bomb" title="Bomb" class="gameObject gameObject-Bomb" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBomb" tabindex="-1" role="dialog" aria-labelledby="Bomb" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5695,7 +5695,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ice bomb" data-quality="5" data-type="Active">
-                        <a href="#modalIce-Bomb" data-toggle="modal"><img alt="Ice Bomb" title="Ice Bomb" class="gameObject gameObject-Ice-Bomb" src="/img/trans.png"></a>
+                        <a href="#modalIce-Bomb" data-toggle="modal"><img alt="Ice Bomb" title="Ice Bomb" class="gameObject gameObject-Ice-Bomb" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalIce-Bomb" tabindex="-1" role="dialog" aria-labelledby="Ice-Bomb" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5715,7 +5715,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="chaff grenade" data-quality="4" data-type="Active">
-                        <a href="#modalChaff-Grenade" data-toggle="modal"><img alt="Chaff Grenade" title="Chaff Grenade" class="gameObject gameObject-Chaff-Grenade" src="/img/trans.png"></a>
+                        <a href="#modalChaff-Grenade" data-toggle="modal"><img alt="Chaff Grenade" title="Chaff Grenade" class="gameObject gameObject-Chaff-Grenade" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalChaff-Grenade" tabindex="-1" role="dialog" aria-labelledby="Chaff-Grenade" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5735,7 +5735,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="proximity mine" data-quality="4" data-type="Active">
-                        <a href="#modalProximity-Mine" data-toggle="modal"><img alt="Proximity Mine" title="Proximity Mine" class="gameObject gameObject-Proximity-Mine" src="/img/trans.png"></a>
+                        <a href="#modalProximity-Mine" data-toggle="modal"><img alt="Proximity Mine" title="Proximity Mine" class="gameObject gameObject-Proximity-Mine" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalProximity-Mine" tabindex="-1" role="dialog" aria-labelledby="Proximity-Mine" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5755,7 +5755,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="cluster mine" data-quality="4" data-type="Active">
-                        <a href="#modalCluster-Mine" data-toggle="modal"><img alt="Cluster Mine" title="Cluster Mine" class="gameObject gameObject-Cluster-Mine" src="/img/trans.png"></a>
+                        <a href="#modalCluster-Mine" data-toggle="modal"><img alt="Cluster Mine" title="Cluster Mine" class="gameObject gameObject-Cluster-Mine" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCluster-Mine" tabindex="-1" role="dialog" aria-labelledby="Cluster-Mine" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5775,7 +5775,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="c4" data-quality="5" data-type="Active">
-                        <a href="#modalC4" data-toggle="modal"><img alt="C4" title="C4" class="gameObject gameObject-C4" src="/img/trans.png"></a>
+                        <a href="#modalC4" data-toggle="modal"><img alt="C4" title="C4" class="gameObject gameObject-C4" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalC4" tabindex="-1" role="dialog" aria-labelledby="C4" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5795,7 +5795,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="molotov" data-quality="5" data-type="Active">
-                        <a href="#modalMolotov" data-toggle="modal"><img alt="Molotov" title="Molotov" class="gameObject gameObject-Molotov" src="/img/trans.png"></a>
+                        <a href="#modalMolotov" data-toggle="modal"><img alt="Molotov" title="Molotov" class="gameObject gameObject-Molotov" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMolotov" tabindex="-1" role="dialog" aria-labelledby="Molotov" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5815,7 +5815,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="air strike" data-quality="3" data-type="Active">
-                        <a href="#modalAir-Strike" data-toggle="modal"><img alt="Air Strike" title="Air Strike" class="gameObject gameObject-Air-Strike" src="/img/trans.png"></a>
+                        <a href="#modalAir-Strike" data-toggle="modal"><img alt="Air Strike" title="Air Strike" class="gameObject gameObject-Air-Strike" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAir-Strike" tabindex="-1" role="dialog" aria-labelledby="Air-Strike" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5835,7 +5835,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="napalm strike" data-quality="3" data-type="Active">
-                        <a href="#modalNapalm-Strike" data-toggle="modal"><img alt="Napalm Strike" title="Napalm Strike" class="gameObject gameObject-Napalm-Strike" src="/img/trans.png"></a>
+                        <a href="#modalNapalm-Strike" data-toggle="modal"><img alt="Napalm Strike" title="Napalm Strike" class="gameObject gameObject-Napalm-Strike" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalNapalm-Strike" tabindex="-1" role="dialog" aria-labelledby="Napalm-Strike" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5855,7 +5855,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="big boy" data-quality="2" data-type="Active">
-                        <a href="#modalBig-Boy" data-toggle="modal"><img alt="Big Boy" title="Big Boy" class="gameObject gameObject-Big-Boy" src="/img/trans.png"></a>
+                        <a href="#modalBig-Boy" data-toggle="modal"><img alt="Big Boy" title="Big Boy" class="gameObject gameObject-Big-Boy" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBig-Boy" tabindex="-1" role="dialog" aria-labelledby="Big-Boy" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5875,7 +5875,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ibomb companion app" data-quality="4" data-type="Active">
-                        <a href="#modaliBomb-Companion-App" data-toggle="modal"><img alt="iBomb Companion App" title="iBomb Companion App" class="gameObject gameObject-iBomb-Companion-App" src="/img/trans.png"></a>
+                        <a href="#modaliBomb-Companion-App" data-toggle="modal"><img alt="iBomb Companion App" title="iBomb Companion App" class="gameObject gameObject-iBomb-Companion-App" src="./img/trans.png"></a>
                         <div class="modal fade" id="modaliBomb-Companion-App" tabindex="-1" role="dialog" aria-labelledby="iBomb-Companion-App" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5895,7 +5895,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="supply drop" data-quality="5" data-type="Active">
-                        <a href="#modalSupply-Drop" data-toggle="modal"><img alt="Supply Drop" title="Supply Drop" class="gameObject gameObject-Supply-Drop" src="/img/trans.png"></a>
+                        <a href="#modalSupply-Drop" data-toggle="modal"><img alt="Supply Drop" title="Supply Drop" class="gameObject gameObject-Supply-Drop" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSupply-Drop" tabindex="-1" role="dialog" aria-labelledby="Supply-Drop" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5915,7 +5915,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ammo synthesizer" data-quality="5" data-type="Passive">
-                        <a href="#modalAmmo-Synthesizer" data-toggle="modal"><img alt="Ammo Synthesizer" title="Ammo Synthesizer" class="gameObject gameObject-Ammo-Synthesizer" src="/img/trans.png"></a>
+                        <a href="#modalAmmo-Synthesizer" data-toggle="modal"><img alt="Ammo Synthesizer" title="Ammo Synthesizer" class="gameObject gameObject-Ammo-Synthesizer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAmmo-Synthesizer" tabindex="-1" role="dialog" aria-labelledby="Ammo-Synthesizer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5935,7 +5935,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="armor synthesizer" data-quality="2" data-type="Passive">
-                        <a href="#modalArmor-Synthesizer" data-toggle="modal"><img alt="Armor Synthesizer" title="Armor Synthesizer" class="gameObject gameObject-Armor-Synthesizer" src="/img/trans.png"></a>
+                        <a href="#modalArmor-Synthesizer" data-toggle="modal"><img alt="Armor Synthesizer" title="Armor Synthesizer" class="gameObject gameObject-Armor-Synthesizer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalArmor-Synthesizer" tabindex="-1" role="dialog" aria-labelledby="Armor-Synthesizer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5955,7 +5955,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heart synthesizer" data-quality="2" data-type="Passive">
-                        <a href="#modalHeart-Synthesizer" data-toggle="modal"><img alt="Heart Synthesizer" title="Heart Synthesizer" class="gameObject gameObject-Heart-Synthesizer" src="/img/trans.png"></a>
+                        <a href="#modalHeart-Synthesizer" data-toggle="modal"><img alt="Heart Synthesizer" title="Heart Synthesizer" class="gameObject gameObject-Heart-Synthesizer" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeart-Synthesizer" tabindex="-1" role="dialog" aria-labelledby="Heart-Synthesizer" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5975,7 +5975,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="master of unlocking" data-quality="3" data-type="Passive">
-                        <a href="#modalMaster-of-Unlocking" data-toggle="modal"><img alt="Master of Unlocking" title="Master of Unlocking" class="gameObject gameObject-Master-of-Unlocking" src="/img/trans.png"></a>
+                        <a href="#modalMaster-of-Unlocking" data-toggle="modal"><img alt="Master of Unlocking" title="Master of Unlocking" class="gameObject gameObject-Master-of-Unlocking" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMaster-of-Unlocking" tabindex="-1" role="dialog" aria-labelledby="Master-of-Unlocking" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -5995,7 +5995,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="utility belt" data-quality="4" data-type="Passive">
-                        <a href="#modalUtility-Belt" data-toggle="modal"><img alt="Utility Belt" title="Utility Belt" class="gameObject gameObject-Utility-Belt" src="/img/trans.png"></a>
+                        <a href="#modalUtility-Belt" data-toggle="modal"><img alt="Utility Belt" title="Utility Belt" class="gameObject gameObject-Utility-Belt" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalUtility-Belt" tabindex="-1" role="dialog" aria-labelledby="Utility-Belt" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6015,7 +6015,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="hidden compartment" data-quality="6" data-type="Passive">
-                        <a href="#modalHidden-Compartment" data-toggle="modal"><img alt="Hidden Compartment" title="Hidden Compartment" class="gameObject gameObject-Hidden-Compartment" src="/img/trans.png"></a>
+                        <a href="#modalHidden-Compartment" data-toggle="modal"><img alt="Hidden Compartment" title="Hidden Compartment" class="gameObject gameObject-Hidden-Compartment" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHidden-Compartment" tabindex="-1" role="dialog" aria-labelledby="Hidden-Compartment" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6035,7 +6035,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="backpack" data-quality="5" data-type="Passive">
-                        <a href="#modalBackpack" data-toggle="modal"><img alt="Backpack" title="Backpack" class="gameObject gameObject-Backpack" src="/img/trans.png"></a>
+                        <a href="#modalBackpack" data-toggle="modal"><img alt="Backpack" title="Backpack" class="gameObject gameObject-Backpack" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBackpack" tabindex="-1" role="dialog" aria-labelledby="Backpack" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6055,7 +6055,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="scope" data-quality="5" data-type="Passive">
-                        <a href="#modalScope" data-toggle="modal"><img alt="Scope" title="Scope" class="gameObject gameObject-Scope" src="/img/trans.png"></a>
+                        <a href="#modalScope" data-toggle="modal"><img alt="Scope" title="Scope" class="gameObject gameObject-Scope" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalScope" tabindex="-1" role="dialog" aria-labelledby="Scope" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6075,7 +6075,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="laser sight" data-type="Passive">
-                        <a href="#modalLaser-Sight" data-toggle="modal"><img alt="Laser Sight" title="Laser Sight" class="gameObject gameObject-Laser-Sight" src="/img/trans.png"></a>
+                        <a href="#modalLaser-Sight" data-toggle="modal"><img alt="Laser Sight" title="Laser Sight" class="gameObject gameObject-Laser-Sight" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLaser-Sight" tabindex="-1" role="dialog" aria-labelledby="Laser-Sight" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6095,7 +6095,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ammo belt" data-quality="5" data-type="Passive">
-                        <a href="#modalAmmo-Belt" data-toggle="modal"><img alt="Ammo Belt" title="Ammo Belt" class="gameObject gameObject-Ammo-Belt" src="/img/trans.png"></a>
+                        <a href="#modalAmmo-Belt" data-toggle="modal"><img alt="Ammo Belt" title="Ammo Belt" class="gameObject gameObject-Ammo-Belt" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAmmo-Belt" tabindex="-1" role="dialog" aria-labelledby="Ammo-Belt" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6115,7 +6115,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bullet time" data-quality="5" data-type="Active">
-                        <a href="#modalBullet-Time" data-toggle="modal"><img alt="Bullet Time" title="Bullet Time" class="gameObject gameObject-Bullet-Time" src="/img/trans.png"></a>
+                        <a href="#modalBullet-Time" data-toggle="modal"><img alt="Bullet Time" title="Bullet Time" class="gameObject gameObject-Bullet-Time" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBullet-Time" tabindex="-1" role="dialog" aria-labelledby="Bullet-Time" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6135,7 +6135,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="aged bell" data-quality="2" data-type="Active">
-                        <a href="#modalAged-Bell" data-toggle="modal"><img alt="Aged Bell" title="Aged Bell" class="gameObject gameObject-Aged-Bell" src="/img/trans.png"></a>
+                        <a href="#modalAged-Bell" data-toggle="modal"><img alt="Aged Bell" title="Aged Bell" class="gameObject gameObject-Aged-Bell" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAged-Bell" tabindex="-1" role="dialog" aria-labelledby="Aged-Bell" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6155,7 +6155,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="singularity" data-quality="4" data-type="Active">
-                        <a href="#modalSingularity" data-toggle="modal"><img alt="Singularity" title="Singularity" class="gameObject gameObject-Singularity" src="/img/trans.png"></a>
+                        <a href="#modalSingularity" data-toggle="modal"><img alt="Singularity" title="Singularity" class="gameObject gameObject-Singularity" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSingularity" tabindex="-1" role="dialog" aria-labelledby="Singularity" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6175,7 +6175,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="decoy" data-quality="5" data-type="Active">
-                        <a href="#modalDecoy" data-toggle="modal"><img alt="Decoy" title="Decoy" class="gameObject gameObject-Decoy" src="/img/trans.png"></a>
+                        <a href="#modalDecoy" data-toggle="modal"><img alt="Decoy" title="Decoy" class="gameObject gameObject-Decoy" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDecoy" tabindex="-1" role="dialog" aria-labelledby="Decoy" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6195,7 +6195,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="explosive decoy" data-quality="4" data-type="Active">
-                        <a href="#modalExplosive-Decoy" data-toggle="modal"><img alt="Explosive Decoy" title="Explosive Decoy" class="gameObject gameObject-Explosive-Decoy" src="/img/trans.png"></a>
+                        <a href="#modalExplosive-Decoy" data-toggle="modal"><img alt="Explosive Decoy" title="Explosive Decoy" class="gameObject gameObject-Explosive-Decoy" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalExplosive-Decoy" tabindex="-1" role="dialog" aria-labelledby="Explosive-Decoy" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6215,7 +6215,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="melted rock" data-quality="4" data-type="Active">
-                        <a href="#modalMelted-Rock" data-toggle="modal"><img alt="Melted Rock" title="Melted Rock" class="gameObject gameObject-Melted-Rock" src="/img/trans.png"></a>
+                        <a href="#modalMelted-Rock" data-toggle="modal"><img alt="Melted Rock" title="Melted Rock" class="gameObject gameObject-Melted-Rock" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMelted-Rock" tabindex="-1" role="dialog" aria-labelledby="Melted-Rock" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6235,7 +6235,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="trusty lockpicks" data-quality="5" data-type="Active">
-                        <a href="#modalTrusty-Lockpicks" data-toggle="modal"><img alt="Trusty Lockpicks" title="Trusty Lockpicks" class="gameObject gameObject-Trusty-Lockpicks" src="/img/trans.png"></a>
+                        <a href="#modalTrusty-Lockpicks" data-toggle="modal"><img alt="Trusty Lockpicks" title="Trusty Lockpicks" class="gameObject gameObject-Trusty-Lockpicks" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTrusty-Lockpicks" tabindex="-1" role="dialog" aria-labelledby="Trusty-Lockpicks" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6255,7 +6255,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="smoke bomb" data-quality="3" data-type="Active">
-                        <a href="#modalSmoke-Bomb" data-toggle="modal"><img alt="Smoke Bomb" title="Smoke Bomb" class="gameObject gameObject-Smoke-Bomb" src="/img/trans.png"></a>
+                        <a href="#modalSmoke-Bomb" data-toggle="modal"><img alt="Smoke Bomb" title="Smoke Bomb" class="gameObject gameObject-Smoke-Bomb" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSmoke-Bomb" tabindex="-1" role="dialog" aria-labelledby="Smoke-Bomb" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6275,7 +6275,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="box" data-quality="2" data-type="Active">
-                        <a href="#modalBox" data-toggle="modal"><img alt="Box" title="Box" class="gameObject gameObject-Box" src="/img/trans.png"></a>
+                        <a href="#modalBox" data-toggle="modal"><img alt="Box" title="Box" class="gameObject gameObject-Box" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBox" tabindex="-1" role="dialog" aria-labelledby="Box" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6295,7 +6295,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="fortune's favor" data-quality="3" data-type="Active">
-                        <a href="#modalFortune_s-Favor" data-toggle="modal"><img alt="Fortune's Favor" title="Fortune's Favor" class="gameObject gameObject-Fortune_s-Favor" src="/img/trans.png"></a>
+                        <a href="#modalFortune_s-Favor" data-toggle="modal"><img alt="Fortune's Favor" title="Fortune's Favor" class="gameObject gameObject-Fortune_s-Favor" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFortune_s-Favor" tabindex="-1" role="dialog" aria-labelledby="Fortune_s-Favor" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6315,7 +6315,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="jar of bees" data-quality="4" data-type="Active">
-                        <a href="#modalJar-of-Bees" data-toggle="modal"><img alt="Jar of Bees" title="Jar of Bees" class="gameObject gameObject-Jar-of-Bees" src="/img/trans.png"></a>
+                        <a href="#modalJar-of-Bees" data-toggle="modal"><img alt="Jar of Bees" title="Jar of Bees" class="gameObject gameObject-Jar-of-Bees" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalJar-of-Bees" tabindex="-1" role="dialog" aria-labelledby="Jar-of-Bees" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6335,7 +6335,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="potion of lead skin" data-quality="5" data-type="Active">
-                        <a href="#modalPotion-of-Lead-Skin" data-toggle="modal"><img alt="Potion of Lead Skin" title="Potion of Lead Skin" class="gameObject gameObject-Potion-of-Lead-Skin" src="/img/trans.png"></a>
+                        <a href="#modalPotion-of-Lead-Skin" data-toggle="modal"><img alt="Potion of Lead Skin" title="Potion of Lead Skin" class="gameObject gameObject-Potion-of-Lead-Skin" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPotion-of-Lead-Skin" tabindex="-1" role="dialog" aria-labelledby="Potion-of-Lead-Skin" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6355,7 +6355,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="double vision" data-quality="5" data-type="Active">
-                        <a href="#modalDouble-Vision" data-toggle="modal"><img alt="Double Vision" title="Double Vision" class="gameObject gameObject-Double-Vision" src="/img/trans.png"></a>
+                        <a href="#modalDouble-Vision" data-toggle="modal"><img alt="Double Vision" title="Double Vision" class="gameObject gameObject-Double-Vision" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDouble-Vision" tabindex="-1" role="dialog" aria-labelledby="Double-Vision" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6375,7 +6375,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="poison vial" data-quality="5" data-type="Active">
-                        <a href="#modalPoison-Vial" data-toggle="modal"><img alt="Poison Vial" title="Poison Vial" class="gameObject gameObject-Poison-Vial" src="/img/trans.png"></a>
+                        <a href="#modalPoison-Vial" data-toggle="modal"><img alt="Poison Vial" title="Poison Vial" class="gameObject gameObject-Poison-Vial" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPoison-Vial" tabindex="-1" role="dialog" aria-labelledby="Poison-Vial" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6395,7 +6395,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="potion of gun friendship" data-quality="5" data-type="Active">
-                        <a href="#modalPotion-of-Gun-Friendship" data-toggle="modal"><img alt="Potion of Gun Friendship" title="Potion of Gun Friendship" class="gameObject gameObject-Potion-of-Gun-Friendship" src="/img/trans.png"></a>
+                        <a href="#modalPotion-of-Gun-Friendship" data-toggle="modal"><img alt="Potion of Gun Friendship" title="Potion of Gun Friendship" class="gameObject gameObject-Potion-of-Gun-Friendship" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPotion-of-Gun-Friendship" tabindex="-1" role="dialog" aria-labelledby="Potion-of-Gun-Friendship" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6415,7 +6415,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="portable turret" data-quality="3" data-type="Active">
-                        <a href="#modalPortable-Turret" data-toggle="modal"><img alt="Portable Turret" title="Portable Turret" class="gameObject gameObject-Portable-Turret" src="/img/trans.png"></a>
+                        <a href="#modalPortable-Turret" data-toggle="modal"><img alt="Portable Turret" title="Portable Turret" class="gameObject gameObject-Portable-Turret" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPortable-Turret" tabindex="-1" role="dialog" aria-labelledby="Portable-Turret" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6435,7 +6435,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="knife shield" data-quality="5" data-type="Active">
-                        <a href="#modalKnife-Shield" data-toggle="modal"><img alt="Knife Shield" title="Knife Shield" class="gameObject gameObject-Knife-Shield" src="/img/trans.png"></a>
+                        <a href="#modalKnife-Shield" data-toggle="modal"><img alt="Knife Shield" title="Knife Shield" class="gameObject gameObject-Knife-Shield" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalKnife-Shield" tabindex="-1" role="dialog" aria-labelledby="Knife-Shield" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6455,7 +6455,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="grappling hook" data-quality="5" data-type="Active">
-                        <a href="#modalGrappling-Hook" data-toggle="modal"><img alt="Grappling Hook" title="Grappling Hook" class="gameObject gameObject-Grappling-Hook" src="/img/trans.png"></a>
+                        <a href="#modalGrappling-Hook" data-toggle="modal"><img alt="Grappling Hook" title="Grappling Hook" class="gameObject gameObject-Grappling-Hook" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGrappling-Hook" tabindex="-1" role="dialog" aria-labelledby="Grappling-Hook" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6475,7 +6475,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="stuffed star" data-quality="4" data-type="Active">
-                        <a href="#modalStuffed-Star" data-toggle="modal"><img alt="Stuffed Star" title="Stuffed Star" class="gameObject gameObject-Stuffed-Star" src="/img/trans.png"></a>
+                        <a href="#modalStuffed-Star" data-toggle="modal"><img alt="Stuffed Star" title="Stuffed Star" class="gameObject gameObject-Stuffed-Star" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalStuffed-Star" tabindex="-1" role="dialog" aria-labelledby="Stuffed-Star" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6495,7 +6495,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="boomerang" data-quality="3" data-type="Active">
-                        <a href="#modalBoomerang" data-toggle="modal"><img alt="Boomerang" title="Boomerang" class="gameObject gameObject-Boomerang" src="/img/trans.png"></a>
+                        <a href="#modalBoomerang" data-toggle="modal"><img alt="Boomerang" title="Boomerang" class="gameObject gameObject-Boomerang" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBoomerang" tabindex="-1" role="dialog" aria-labelledby="Boomerang" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6515,7 +6515,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="shield of the maiden" data-quality="4" data-type="Active">
-                        <a href="#modalShield-of-the-Maiden" data-toggle="modal"><img alt="Shield of the Maiden" title="Shield of the Maiden" class="gameObject gameObject-Shield-of-the-Maiden" src="/img/trans.png"></a>
+                        <a href="#modalShield-of-the-Maiden" data-toggle="modal"><img alt="Shield of the Maiden" title="Shield of the Maiden" class="gameObject gameObject-Shield-of-the-Maiden" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShield-of-the-Maiden" tabindex="-1" role="dialog" aria-labelledby="Shield-of-the-Maiden" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6535,7 +6535,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="+1 bullets" data-quality="4" data-type="Passive">
-                        <a href="#modal1-Bullets" data-toggle="modal"><img alt="+1 Bullets" title="+1 Bullets" class="gameObject gameObject-1-Bullets" src="/img/trans.png"></a>
+                        <a href="#modal1-Bullets" data-toggle="modal"><img alt="+1 Bullets" title="+1 Bullets" class="gameObject gameObject-1-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modal1-Bullets" tabindex="-1" role="dialog" aria-labelledby="1-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6555,7 +6555,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="rocket-powered bullets" data-quality="3" data-type="Passive">
-                        <a href="#modalRocket-Powered-Bullets" data-toggle="modal"><img alt="Rocket-Powered Bullets" title="Rocket-Powered Bullets" class="gameObject gameObject-Rocket-Powered-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalRocket-Powered-Bullets" data-toggle="modal"><img alt="Rocket-Powered Bullets" title="Rocket-Powered Bullets" class="gameObject gameObject-Rocket-Powered-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRocket-Powered-Bullets" tabindex="-1" role="dialog" aria-labelledby="Rocket-Powered-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6575,7 +6575,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heavy bullets" data-quality="4" data-type="Passive">
-                        <a href="#modalHeavy-Bullets" data-toggle="modal"><img alt="Heavy Bullets" title="Heavy Bullets" class="gameObject gameObject-Heavy-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalHeavy-Bullets" data-toggle="modal"><img alt="Heavy Bullets" title="Heavy Bullets" class="gameObject gameObject-Heavy-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeavy-Bullets" tabindex="-1" role="dialog" aria-labelledby="Heavy-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6595,7 +6595,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="shock rounds" data-quality="1" data-type="Passive">
-                        <a href="#modalShock-Rounds" data-toggle="modal"><img alt="Shock Rounds" title="Shock Rounds" class="gameObject gameObject-Shock-Rounds" src="/img/trans.png"></a>
+                        <a href="#modalShock-Rounds" data-toggle="modal"><img alt="Shock Rounds" title="Shock Rounds" class="gameObject gameObject-Shock-Rounds" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShock-Rounds" tabindex="-1" role="dialog" aria-labelledby="Shock-Rounds" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6615,7 +6615,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bouncy bullets" data-quality="4" data-type="Passive">
-                        <a href="#modalBouncy-Bullets" data-toggle="modal"><img alt="Bouncy Bullets" title="Bouncy Bullets" class="gameObject gameObject-Bouncy-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalBouncy-Bullets" data-toggle="modal"><img alt="Bouncy Bullets" title="Bouncy Bullets" class="gameObject gameObject-Bouncy-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBouncy-Bullets" tabindex="-1" role="dialog" aria-labelledby="Bouncy-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6635,7 +6635,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="explosive rounds" data-quality="2" data-type="Passive">
-                        <a href="#modalExplosive-Rounds" data-toggle="modal"><img alt="Explosive Rounds" title="Explosive Rounds" class="gameObject gameObject-Explosive-Rounds" src="/img/trans.png"></a>
+                        <a href="#modalExplosive-Rounds" data-toggle="modal"><img alt="Explosive Rounds" title="Explosive Rounds" class="gameObject gameObject-Explosive-Rounds" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalExplosive-Rounds" tabindex="-1" role="dialog" aria-labelledby="Explosive-Rounds" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6655,7 +6655,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ghost bullets" data-quality="4" data-type="Passive">
-                        <a href="#modalGhost-Bullets" data-toggle="modal"><img alt="Ghost Bullets" title="Ghost Bullets" class="gameObject gameObject-Ghost-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalGhost-Bullets" data-toggle="modal"><img alt="Ghost Bullets" title="Ghost Bullets" class="gameObject gameObject-Ghost-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGhost-Bullets" tabindex="-1" role="dialog" aria-labelledby="Ghost-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6675,7 +6675,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="alpha bullets" data-quality="2" data-type="Passive">
-                        <a href="#modalAlpha-Bullets" data-toggle="modal"><img alt="Alpha Bullets" title="Alpha Bullets" class="gameObject gameObject-Alpha-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalAlpha-Bullets" data-toggle="modal"><img alt="Alpha Bullets" title="Alpha Bullets" class="gameObject gameObject-Alpha-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAlpha-Bullets" tabindex="-1" role="dialog" aria-labelledby="Alpha-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6695,7 +6695,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="omega bullets" data-quality="2" data-type="Passive">
-                        <a href="#modalOmega-Bullets" data-toggle="modal"><img alt="Omega Bullets" title="Omega Bullets" class="gameObject gameObject-Omega-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalOmega-Bullets" data-toggle="modal"><img alt="Omega Bullets" title="Omega Bullets" class="gameObject gameObject-Omega-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOmega-Bullets" tabindex="-1" role="dialog" aria-labelledby="Omega-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6715,7 +6715,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="scattershot" data-quality="2" data-type="Passive">
-                        <a href="#modalScattershot" data-toggle="modal"><img alt="Scattershot" title="Scattershot" class="gameObject gameObject-Scattershot" src="/img/trans.png"></a>
+                        <a href="#modalScattershot" data-toggle="modal"><img alt="Scattershot" title="Scattershot" class="gameObject gameObject-Scattershot" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalScattershot" tabindex="-1" role="dialog" aria-labelledby="Scattershot" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6735,7 +6735,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="irradiated lead" data-quality="3" data-type="Passive">
-                        <a href="#modalIrradiated-Lead" data-toggle="modal"><img alt="Irradiated Lead" title="Irradiated Lead" class="gameObject gameObject-Irradiated-Lead" src="/img/trans.png"></a>
+                        <a href="#modalIrradiated-Lead" data-toggle="modal"><img alt="Irradiated Lead" title="Irradiated Lead" class="gameObject gameObject-Irradiated-Lead" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalIrradiated-Lead" tabindex="-1" role="dialog" aria-labelledby="Irradiated-Lead" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6755,7 +6755,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="hot lead" data-quality="3" data-type="Passive">
-                        <a href="#modalHot-Lead" data-toggle="modal"><img alt="Hot Lead" title="Hot Lead" class="gameObject gameObject-Hot-Lead" src="/img/trans.png"></a>
+                        <a href="#modalHot-Lead" data-toggle="modal"><img alt="Hot Lead" title="Hot Lead" class="gameObject gameObject-Hot-Lead" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHot-Lead" tabindex="-1" role="dialog" aria-labelledby="Hot-Lead" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6775,7 +6775,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="frost bullets" data-quality="2" data-type="Passive">
-                        <a href="#modalFrost-Bullets" data-toggle="modal"><img alt="Frost Bullets" title="Frost Bullets" class="gameObject gameObject-Frost-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalFrost-Bullets" data-toggle="modal"><img alt="Frost Bullets" title="Frost Bullets" class="gameObject gameObject-Frost-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFrost-Bullets" tabindex="-1" role="dialog" aria-labelledby="Frost-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6795,7 +6795,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="fat bullets" data-quality="2" data-type="Passive">
-                        <a href="#modalFat-Bullets" data-toggle="modal"><img alt="Fat Bullets" title="Fat Bullets" class="gameObject gameObject-Fat-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalFat-Bullets" data-toggle="modal"><img alt="Fat Bullets" title="Fat Bullets" class="gameObject gameObject-Fat-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFat-Bullets" tabindex="-1" role="dialog" aria-labelledby="Fat-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6815,7 +6815,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="angry bullets" data-quality="4" data-type="Passive">
-                        <a href="#modalAngry-Bullets" data-toggle="modal"><img alt="Angry Bullets" title="Angry Bullets" class="gameObject gameObject-Angry-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalAngry-Bullets" data-toggle="modal"><img alt="Angry Bullets" title="Angry Bullets" class="gameObject gameObject-Angry-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAngry-Bullets" tabindex="-1" role="dialog" aria-labelledby="Angry-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6835,7 +6835,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="battery bullets" data-type="Passive">
-                        <a href="#modalBattery-Bullets" data-toggle="modal"><img alt="Battery Bullets" title="Battery Bullets" class="gameObject gameObject-Battery-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalBattery-Bullets" data-toggle="modal"><img alt="Battery Bullets" title="Battery Bullets" class="gameObject gameObject-Battery-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBattery-Bullets" tabindex="-1" role="dialog" aria-labelledby="Battery-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6855,7 +6855,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="homing bullets" data-quality="3" data-type="Passive">
-                        <a href="#modalHoming-Bullets" data-toggle="modal"><img alt="Homing Bullets" title="Homing Bullets" class="gameObject gameObject-Homing-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalHoming-Bullets" data-toggle="modal"><img alt="Homing Bullets" title="Homing Bullets" class="gameObject gameObject-Homing-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHoming-Bullets" tabindex="-1" role="dialog" aria-labelledby="Homing-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6875,7 +6875,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="shadow bullets" data-quality="3" data-type="Passive">
-                        <a href="#modalShadow-Bullets" data-toggle="modal"><img alt="Shadow Bullets" title="Shadow Bullets" class="gameObject gameObject-Shadow-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalShadow-Bullets" data-toggle="modal"><img alt="Shadow Bullets" title="Shadow Bullets" class="gameObject gameObject-Shadow-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShadow-Bullets" tabindex="-1" role="dialog" aria-labelledby="Shadow-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6895,7 +6895,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="easy reload bullets" data-quality="4" data-type="Passive">
-                        <a href="#modalEasy-Reload-Bullets" data-toggle="modal"><img alt="Easy Reload Bullets" title="Easy Reload Bullets" class="gameObject gameObject-Easy-Reload-Bullets" src="/img/trans.png"></a>
+                        <a href="#modalEasy-Reload-Bullets" data-toggle="modal"><img alt="Easy Reload Bullets" title="Easy Reload Bullets" class="gameObject gameObject-Easy-Reload-Bullets" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalEasy-Reload-Bullets" tabindex="-1" role="dialog" aria-labelledby="Easy-Reload-Bullets" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6915,7 +6915,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bionic leg" data-quality="4" data-type="Passive">
-                        <a href="#modalBionic-Leg" data-toggle="modal"><img alt="Bionic Leg" title="Bionic Leg" class="gameObject gameObject-Bionic-Leg" src="/img/trans.png"></a>
+                        <a href="#modalBionic-Leg" data-toggle="modal"><img alt="Bionic Leg" title="Bionic Leg" class="gameObject gameObject-Bionic-Leg" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBionic-Leg" tabindex="-1" role="dialog" aria-labelledby="Bionic-Leg" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6935,7 +6935,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="shotgun coffee" data-quality="4" data-type="Passive">
-                        <a href="#modalShotgun-Coffee" data-toggle="modal"><img alt="Shotgun Coffee" title="Shotgun Coffee" class="gameObject gameObject-Shotgun-Coffee" src="/img/trans.png"></a>
+                        <a href="#modalShotgun-Coffee" data-toggle="modal"><img alt="Shotgun Coffee" title="Shotgun Coffee" class="gameObject gameObject-Shotgun-Coffee" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShotgun-Coffee" tabindex="-1" role="dialog" aria-labelledby="Shotgun-Coffee" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6955,7 +6955,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="shotga cola" data-quality="4" data-type="Passive">
-                        <a href="#modalShotga-Cola" data-toggle="modal"><img alt="Shotga Cola" title="Shotga Cola" class="gameObject gameObject-Shotga-Cola" src="/img/trans.png"></a>
+                        <a href="#modalShotga-Cola" data-toggle="modal"><img alt="Shotga Cola" title="Shotga Cola" class="gameObject gameObject-Shotga-Cola" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShotga-Cola" tabindex="-1" role="dialog" aria-labelledby="Shotga-Cola" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6975,7 +6975,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ballistic boots" data-quality="3" data-type="Passive">
-                        <a href="#modalBallistic-Boots" data-toggle="modal"><img alt="Ballistic Boots" title="Ballistic Boots" class="gameObject gameObject-Ballistic-Boots" src="/img/trans.png"></a>
+                        <a href="#modalBallistic-Boots" data-toggle="modal"><img alt="Ballistic Boots" title="Ballistic Boots" class="gameObject gameObject-Ballistic-Boots" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBallistic-Boots" tabindex="-1" role="dialog" aria-labelledby="Ballistic-Boots" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -6995,7 +6995,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="magic sweet" data-quality="2" data-type="Passive">
-                        <a href="#modalMagic-Sweet" data-toggle="modal"><img alt="Magic Sweet" title="Magic Sweet" class="gameObject gameObject-Magic-Sweet" src="/img/trans.png"></a>
+                        <a href="#modalMagic-Sweet" data-toggle="modal"><img alt="Magic Sweet" title="Magic Sweet" class="gameObject gameObject-Magic-Sweet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMagic-Sweet" tabindex="-1" role="dialog" aria-labelledby="Magic-Sweet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7015,7 +7015,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="disarming personality" data-quality="4" data-type="Passive">
-                        <a href="#modalDisarming-Personality" data-toggle="modal"><img alt="Disarming Personality" title="Disarming Personality" class="gameObject gameObject-Disarming-Personality" src="/img/trans.png"></a>
+                        <a href="#modalDisarming-Personality" data-toggle="modal"><img alt="Disarming Personality" title="Disarming Personality" class="gameObject gameObject-Disarming-Personality" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDisarming-Personality" tabindex="-1" role="dialog" aria-labelledby="Disarming-Personality" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7035,7 +7035,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="mustache" data-quality="4" data-type="Passive">
-                        <a href="#modalMustache" data-toggle="modal"><img alt="Mustache" title="Mustache" class="gameObject gameObject-Mustache" src="/img/trans.png"></a>
+                        <a href="#modalMustache" data-toggle="modal"><img alt="Mustache" title="Mustache" class="gameObject gameObject-Mustache" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMustache" tabindex="-1" role="dialog" aria-labelledby="Mustache" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7055,7 +7055,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="lichy trigger finger" data-quality="5" data-type="Passive">
-                        <a href="#modalLichy-Trigger-Finger" data-toggle="modal"><img alt="Lichy Trigger Finger" title="Lichy Trigger Finger" class="gameObject gameObject-Lichy-Trigger-Finger" src="/img/trans.png"></a>
+                        <a href="#modalLichy-Trigger-Finger" data-toggle="modal"><img alt="Lichy Trigger Finger" title="Lichy Trigger Finger" class="gameObject gameObject-Lichy-Trigger-Finger" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLichy-Trigger-Finger" tabindex="-1" role="dialog" aria-labelledby="Lichy-Trigger-Finger" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7075,7 +7075,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="enraging photo" data-type="Passive">
-                        <a href="#modalEnraging-Photo" data-toggle="modal"><img alt="Enraging Photo" title="Enraging Photo" class="gameObject gameObject-Enraging-Photo" src="/img/trans.png"></a>
+                        <a href="#modalEnraging-Photo" data-toggle="modal"><img alt="Enraging Photo" title="Enraging Photo" class="gameObject gameObject-Enraging-Photo" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalEnraging-Photo" tabindex="-1" role="dialog" aria-labelledby="Enraging-Photo" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7095,7 +7095,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ballot" data-quality="3" data-type="Passive">
-                        <a href="#modalBallot" data-toggle="modal"><img alt="Ballot" title="Ballot" class="gameObject gameObject-Ballot" src="/img/trans.png"></a>
+                        <a href="#modalBallot" data-toggle="modal"><img alt="Ballot" title="Ballot" class="gameObject gameObject-Ballot" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBallot" tabindex="-1" role="dialog" aria-labelledby="Ballot" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7115,7 +7115,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="live ammo" data-quality="6" data-type="Passive">
-                        <a href="#modalLive-Ammo" data-toggle="modal"><img alt="Live Ammo" title="Live Ammo" class="gameObject gameObject-Live-Ammo" src="/img/trans.png"></a>
+                        <a href="#modalLive-Ammo" data-toggle="modal"><img alt="Live Ammo" title="Live Ammo" class="gameObject gameObject-Live-Ammo" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLive-Ammo" tabindex="-1" role="dialog" aria-labelledby="Live-Ammo" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7135,7 +7135,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="eyepatch" data-quality="2" data-type="Passive">
-                        <a href="#modalEyepatch" data-toggle="modal"><img alt="Eyepatch" title="Eyepatch" class="gameObject gameObject-Eyepatch" src="/img/trans.png"></a>
+                        <a href="#modalEyepatch" data-toggle="modal"><img alt="Eyepatch" title="Eyepatch" class="gameObject gameObject-Eyepatch" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalEyepatch" tabindex="-1" role="dialog" aria-labelledby="Eyepatch" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7155,7 +7155,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="military training" data-quality="4" data-type="Passive">
-                        <a href="#modalMilitary-Training" data-toggle="modal"><img alt="Military Training" title="Military Training" class="gameObject gameObject-Military-Training" src="/img/trans.png"></a>
+                        <a href="#modalMilitary-Training" data-toggle="modal"><img alt="Military Training" title="Military Training" class="gameObject gameObject-Military-Training" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMilitary-Training" tabindex="-1" role="dialog" aria-labelledby="Military-Training" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7175,7 +7175,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="cartographer's ring" data-quality="4" data-type="Passive">
-                        <a href="#modalCartographer_s-Ring" data-toggle="modal"><img alt="Cartographer's Ring" title="Cartographer's Ring" class="gameObject gameObject-Cartographer_s-Ring" src="/img/trans.png"></a>
+                        <a href="#modalCartographer_s-Ring" data-toggle="modal"><img alt="Cartographer's Ring" title="Cartographer's Ring" class="gameObject gameObject-Cartographer_s-Ring" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCartographer_s-Ring" tabindex="-1" role="dialog" aria-labelledby="Cartographer_s-Ring" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7195,7 +7195,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ring of fire resistance" data-quality="4" data-type="Passive">
-                        <a href="#modalRing-of-Fire-Resistance" data-toggle="modal"><img alt="Ring of Fire Resistance" title="Ring of Fire Resistance" class="gameObject gameObject-Ring-of-Fire-Resistance" src="/img/trans.png"></a>
+                        <a href="#modalRing-of-Fire-Resistance" data-toggle="modal"><img alt="Ring of Fire Resistance" title="Ring of Fire Resistance" class="gameObject gameObject-Ring-of-Fire-Resistance" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRing-of-Fire-Resistance" tabindex="-1" role="dialog" aria-labelledby="Ring-of-Fire-Resistance" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7215,7 +7215,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ring of miserly protection" data-quality="4" data-type="Passive">
-                        <a href="#modalRing-of-Miserly-Protection" data-toggle="modal"><img alt="Ring of Miserly Protection" title="Ring of Miserly Protection" class="gameObject gameObject-Ring-of-Miserly-Protection" src="/img/trans.png"></a>
+                        <a href="#modalRing-of-Miserly-Protection" data-toggle="modal"><img alt="Ring of Miserly Protection" title="Ring of Miserly Protection" class="gameObject gameObject-Ring-of-Miserly-Protection" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRing-of-Miserly-Protection" tabindex="-1" role="dialog" aria-labelledby="Ring-of-Miserly-Protection" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7235,7 +7235,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="unity" data-quality="3" data-type="Passive">
-                        <a href="#modalUnity" data-toggle="modal"><img alt="Unity" title="Unity" class="gameObject gameObject-Unity" src="/img/trans.png"></a>
+                        <a href="#modalUnity" data-toggle="modal"><img alt="Unity" title="Unity" class="gameObject gameObject-Unity" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalUnity" tabindex="-1" role="dialog" aria-labelledby="Unity" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7255,7 +7255,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ring of chest vampirism" data-quality="3" data-type="Passive">
-                        <a href="#modalRing-of-Chest-Vampirism" data-toggle="modal"><img alt="Ring of Chest Vampirism" title="Ring of Chest Vampirism" class="gameObject gameObject-Ring-of-Chest-Vampirism" src="/img/trans.png"></a>
+                        <a href="#modalRing-of-Chest-Vampirism" data-toggle="modal"><img alt="Ring of Chest Vampirism" title="Ring of Chest Vampirism" class="gameObject gameObject-Ring-of-Chest-Vampirism" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRing-of-Chest-Vampirism" tabindex="-1" role="dialog" aria-labelledby="Ring-of-Chest-Vampirism" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7275,7 +7275,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="cloranthy ring" data-quality="4" data-type="Passive">
-                        <a href="#modalCloranthy-Ring" data-toggle="modal"><img alt="Cloranthy Ring" title="Cloranthy Ring" class="gameObject gameObject-Cloranthy-Ring" src="/img/trans.png"></a>
+                        <a href="#modalCloranthy-Ring" data-toggle="modal"><img alt="Cloranthy Ring" title="Cloranthy Ring" class="gameObject gameObject-Cloranthy-Ring" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCloranthy-Ring" tabindex="-1" role="dialog" aria-labelledby="Cloranthy-Ring" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7295,7 +7295,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ring of chest friendship" data-quality="3" data-type="Passive">
-                        <a href="#modalRing-of-Chest-Friendship" data-toggle="modal"><img alt="Ring of Chest Friendship" title="Ring of Chest Friendship" class="gameObject gameObject-Ring-of-Chest-Friendship" src="/img/trans.png"></a>
+                        <a href="#modalRing-of-Chest-Friendship" data-toggle="modal"><img alt="Ring of Chest Friendship" title="Ring of Chest Friendship" class="gameObject gameObject-Ring-of-Chest-Friendship" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRing-of-Chest-Friendship" tabindex="-1" role="dialog" aria-labelledby="Ring-of-Chest-Friendship" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7315,7 +7315,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ring of mimic friendship" data-quality="5" data-type="Passive">
-                        <a href="#modalRing-of-Mimic-Friendship" data-toggle="modal"><img alt="Ring of Mimic Friendship" title="Ring of Mimic Friendship" class="gameObject gameObject-Ring-of-Mimic-Friendship" src="/img/trans.png"></a>
+                        <a href="#modalRing-of-Mimic-Friendship" data-toggle="modal"><img alt="Ring of Mimic Friendship" title="Ring of Mimic Friendship" class="gameObject gameObject-Ring-of-Mimic-Friendship" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRing-of-Mimic-Friendship" tabindex="-1" role="dialog" aria-labelledby="Ring-of-Mimic-Friendship" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7335,7 +7335,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ring of triggers" data-quality="2" data-type="Passive">
-                        <a href="#modalRing-of-Triggers" data-toggle="modal"><img alt="Ring of Triggers" title="Ring of Triggers" class="gameObject gameObject-Ring-of-Triggers" src="/img/trans.png"></a>
+                        <a href="#modalRing-of-Triggers" data-toggle="modal"><img alt="Ring of Triggers" title="Ring of Triggers" class="gameObject gameObject-Ring-of-Triggers" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRing-of-Triggers" tabindex="-1" role="dialog" aria-labelledby="Ring-of-Triggers" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7355,7 +7355,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ring of ethereal form" data-quality="3" data-type="Active">
-                        <a href="#modalRing-of-Ethereal-Form" data-toggle="modal"><img alt="Ring of Ethereal Form" title="Ring of Ethereal Form" class="gameObject gameObject-Ring-of-Ethereal-Form" src="/img/trans.png"></a>
+                        <a href="#modalRing-of-Ethereal-Form" data-toggle="modal"><img alt="Ring of Ethereal Form" title="Ring of Ethereal Form" class="gameObject gameObject-Ring-of-Ethereal-Form" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRing-of-Ethereal-Form" tabindex="-1" role="dialog" aria-labelledby="Ring-of-Ethereal-Form" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7375,7 +7375,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gundromeda strain" data-quality="1" data-type="Passive">
-                        <a href="#modalGundromeda-Strain" data-toggle="modal"><img alt="Gundromeda Strain" title="Gundromeda Strain" class="gameObject gameObject-Gundromeda-Strain" src="/img/trans.png"></a>
+                        <a href="#modalGundromeda-Strain" data-toggle="modal"><img alt="Gundromeda Strain" title="Gundromeda Strain" class="gameObject gameObject-Gundromeda-Strain" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGundromeda-Strain" tabindex="-1" role="dialog" aria-labelledby="Gundromeda-Strain" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7395,7 +7395,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="broccoli" data-quality="1" data-type="Passive">
-                        <a href="#modalBroccoli" data-toggle="modal"><img alt="Broccoli" title="Broccoli" class="gameObject gameObject-Broccoli" src="/img/trans.png"></a>
+                        <a href="#modalBroccoli" data-toggle="modal"><img alt="Broccoli" title="Broccoli" class="gameObject gameObject-Broccoli" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBroccoli" tabindex="-1" role="dialog" aria-labelledby="Broccoli" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7415,7 +7415,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="crutch" data-quality="3" data-type="Passive">
-                        <a href="#modalCrutch" data-toggle="modal"><img alt="Crutch" title="Crutch" class="gameObject gameObject-Crutch" src="/img/trans.png"></a>
+                        <a href="#modalCrutch" data-toggle="modal"><img alt="Crutch" title="Crutch" class="gameObject gameObject-Crutch" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCrutch" tabindex="-1" role="dialog" aria-labelledby="Crutch" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7435,7 +7435,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="liquid valkyrie" data-quality="2" data-type="Passive">
-                        <a href="#modalLiquid-Valkyrie" data-toggle="modal"><img alt="Liquid Valkyrie" title="Liquid Valkyrie" class="gameObject gameObject-Liquid-Valkyrie" src="/img/trans.png"></a>
+                        <a href="#modalLiquid-Valkyrie" data-toggle="modal"><img alt="Liquid Valkyrie" title="Liquid Valkyrie" class="gameObject gameObject-Liquid-Valkyrie" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLiquid-Valkyrie" tabindex="-1" role="dialog" aria-labelledby="Liquid-Valkyrie" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7455,7 +7455,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bloody eye" data-quality="3" data-type="Passive">
-                        <a href="#modalBloody-Eye" data-toggle="modal"><img alt="Bloody Eye" title="Bloody Eye" class="gameObject gameObject-Bloody-Eye" src="/img/trans.png"></a>
+                        <a href="#modalBloody-Eye" data-toggle="modal"><img alt="Bloody Eye" title="Bloody Eye" class="gameObject gameObject-Bloody-Eye" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBloody-Eye" tabindex="-1" role="dialog" aria-labelledby="Bloody-Eye" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7475,7 +7475,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gunknight helmet" data-quality="2" data-type="Passive">
-                        <a href="#modalGunknight-Helmet" data-toggle="modal"><img alt="Gunknight Helmet" title="Gunknight Helmet" class="gameObject gameObject-Gunknight-Helmet" src="/img/trans.png"></a>
+                        <a href="#modalGunknight-Helmet" data-toggle="modal"><img alt="Gunknight Helmet" title="Gunknight Helmet" class="gameObject gameObject-Gunknight-Helmet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunknight-Helmet" tabindex="-1" role="dialog" aria-labelledby="Gunknight-Helmet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7495,7 +7495,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gunknight greaves" data-quality="4" data-type="Passive">
-                        <a href="#modalGunknight-Greaves" data-toggle="modal"><img alt="Gunknight Greaves" title="Gunknight Greaves" class="gameObject gameObject-Gunknight-Greaves" src="/img/trans.png"></a>
+                        <a href="#modalGunknight-Greaves" data-toggle="modal"><img alt="Gunknight Greaves" title="Gunknight Greaves" class="gameObject gameObject-Gunknight-Greaves" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunknight-Greaves" tabindex="-1" role="dialog" aria-labelledby="Gunknight-Greaves" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7515,7 +7515,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gunknight armor" data-quality="3" data-type="Passive">
-                        <a href="#modalGunknight-Armor" data-toggle="modal"><img alt="Gunknight Armor" title="Gunknight Armor" class="gameObject gameObject-Gunknight-Armor" src="/img/trans.png"></a>
+                        <a href="#modalGunknight-Armor" data-toggle="modal"><img alt="Gunknight Armor" title="Gunknight Armor" class="gameObject gameObject-Gunknight-Armor" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunknight-Armor" tabindex="-1" role="dialog" aria-labelledby="Gunknight-Armor" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7535,7 +7535,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gunknight gauntlet" data-quality="4" data-type="Passive">
-                        <a href="#modalGunknight-Gauntlet" data-toggle="modal"><img alt="Gunknight Gauntlet" title="Gunknight Gauntlet" class="gameObject gameObject-Gunknight-Gauntlet" src="/img/trans.png"></a>
+                        <a href="#modalGunknight-Gauntlet" data-toggle="modal"><img alt="Gunknight Gauntlet" title="Gunknight Gauntlet" class="gameObject gameObject-Gunknight-Gauntlet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunknight-Gauntlet" tabindex="-1" role="dialog" aria-labelledby="Gunknight-Gauntlet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7555,7 +7555,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="amulet of the pit lord" data-quality="5" data-type="Passive">
-                        <a href="#modalAmulet-of-the-Pit-Lord" data-toggle="modal"><img alt="Amulet of the Pit Lord" title="Amulet of the Pit Lord" class="gameObject gameObject-Amulet-of-the-Pit-Lord" src="/img/trans.png"></a>
+                        <a href="#modalAmulet-of-the-Pit-Lord" data-toggle="modal"><img alt="Amulet of the Pit Lord" title="Amulet of the Pit Lord" class="gameObject gameObject-Amulet-of-the-Pit-Lord" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAmulet-of-the-Pit-Lord" tabindex="-1" role="dialog" aria-labelledby="Amulet-of-the-Pit-Lord" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7575,7 +7575,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="old knight's shield" data-type="Passive">
-                        <a href="#modalOld-Knight_s-Shield" data-toggle="modal"><img alt="Old Knight's Shield" title="Old Knight's Shield" class="gameObject gameObject-Old-Knight_s-Shield" src="/img/trans.png"></a>
+                        <a href="#modalOld-Knight_s-Shield" data-toggle="modal"><img alt="Old Knight's Shield" title="Old Knight's Shield" class="gameObject gameObject-Old-Knight_s-Shield" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOld-Knight_s-Shield" tabindex="-1" role="dialog" aria-labelledby="Old-Knight_s-Shield" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7595,7 +7595,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="old knight's helm" data-type="Passive">
-                        <a href="#modalOld-Knight_s-Helm" data-toggle="modal"><img alt="Old Knight's Helm" title="Old Knight's Helm" class="gameObject gameObject-Old-Knight_s-Helm" src="/img/trans.png"></a>
+                        <a href="#modalOld-Knight_s-Helm" data-toggle="modal"><img alt="Old Knight's Helm" title="Old Knight's Helm" class="gameObject gameObject-Old-Knight_s-Helm" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOld-Knight_s-Helm" tabindex="-1" role="dialog" aria-labelledby="Old-Knight_s-Helm" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7615,7 +7615,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="old knight's flask" data-quality="2" data-type="Active">
-                        <a href="#modalOld-Knight_s-Flask" data-toggle="modal"><img alt="Old Knight's Flask" title="Old Knight's Flask" class="gameObject gameObject-Old-Knight_s-Flask" src="/img/trans.png"></a>
+                        <a href="#modalOld-Knight_s-Flask" data-toggle="modal"><img alt="Old Knight's Flask" title="Old Knight's Flask" class="gameObject gameObject-Old-Knight_s-Flask" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOld-Knight_s-Flask" tabindex="-1" role="dialog" aria-labelledby="Old-Knight_s-Flask" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7635,7 +7635,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="old crest" data-quality="6" data-type="Passive">
-                        <a href="#modalOld-Crest" data-toggle="modal"><img alt="Old Crest" title="Old Crest" class="gameObject gameObject-Old-Crest" src="/img/trans.png"></a>
+                        <a href="#modalOld-Crest" data-toggle="modal"><img alt="Old Crest" title="Old Crest" class="gameObject gameObject-Old-Crest" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOld-Crest" tabindex="-1" role="dialog" aria-labelledby="Old-Crest" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7655,7 +7655,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="armor of thorns" data-quality="4" data-type="Passive">
-                        <a href="#modalArmor-of-Thorns" data-toggle="modal"><img alt="Armor of Thorns" title="Armor of Thorns" class="gameObject gameObject-Armor-of-Thorns" src="/img/trans.png"></a>
+                        <a href="#modalArmor-of-Thorns" data-toggle="modal"><img alt="Armor of Thorns" title="Armor of Thorns" class="gameObject gameObject-Armor-of-Thorns" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalArmor-of-Thorns" tabindex="-1" role="dialog" aria-labelledby="Armor-of-Thorns" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7675,7 +7675,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heavy boots" data-quality="5" data-type="Passive">
-                        <a href="#modalHeavy-Boots" data-toggle="modal"><img alt="Heavy Boots" title="Heavy Boots" class="gameObject gameObject-Heavy-Boots" src="/img/trans.png"></a>
+                        <a href="#modalHeavy-Boots" data-toggle="modal"><img alt="Heavy Boots" title="Heavy Boots" class="gameObject gameObject-Heavy-Boots" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeavy-Boots" tabindex="-1" role="dialog" aria-labelledby="Heavy-Boots" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7695,7 +7695,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bug boots" data-quality="3" data-type="Passive">
-                        <a href="#modalBug-Boots" data-toggle="modal"><img alt="Bug Boots" title="Bug Boots" class="gameObject gameObject-Bug-Boots" src="/img/trans.png"></a>
+                        <a href="#modalBug-Boots" data-toggle="modal"><img alt="Bug Boots" title="Bug Boots" class="gameObject gameObject-Bug-Boots" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBug-Boots" tabindex="-1" role="dialog" aria-labelledby="Bug-Boots" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7715,7 +7715,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gunboots" data-quality="4" data-type="Passive">
-                        <a href="#modalGunboots" data-toggle="modal"><img alt="Gunboots" title="Gunboots" class="gameObject gameObject-Gunboots" src="/img/trans.png"></a>
+                        <a href="#modalGunboots" data-toggle="modal"><img alt="Gunboots" title="Gunboots" class="gameObject gameObject-Gunboots" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGunboots" tabindex="-1" role="dialog" aria-labelledby="Gunboots" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7735,7 +7735,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="coin crown" data-quality="4" data-type="Passive">
-                        <a href="#modalCoin-Crown" data-toggle="modal"><img alt="Coin Crown" title="Coin Crown" class="gameObject gameObject-Coin-Crown" src="/img/trans.png"></a>
+                        <a href="#modalCoin-Crown" data-toggle="modal"><img alt="Coin Crown" title="Coin Crown" class="gameObject gameObject-Coin-Crown" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCoin-Crown" tabindex="-1" role="dialog" aria-labelledby="Coin-Crown" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7755,7 +7755,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="oiled cylinder" data-quality="4" data-type="Passive">
-                        <a href="#modalOiled-Cylinder" data-toggle="modal"><img alt="Oiled Cylinder" title="Oiled Cylinder" class="gameObject gameObject-Oiled-Cylinder" src="/img/trans.png"></a>
+                        <a href="#modalOiled-Cylinder" data-toggle="modal"><img alt="Oiled Cylinder" title="Oiled Cylinder" class="gameObject gameObject-Oiled-Cylinder" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOiled-Cylinder" tabindex="-1" role="dialog" aria-labelledby="Oiled-Cylinder" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7775,7 +7775,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ice cube" data-quality="3" data-type="Passive">
-                        <a href="#modalIce-Cube" data-toggle="modal"><img alt="Ice Cube" title="Ice Cube" class="gameObject gameObject-Ice-Cube" src="/img/trans.png"></a>
+                        <a href="#modalIce-Cube" data-toggle="modal"><img alt="Ice Cube" title="Ice Cube" class="gameObject gameObject-Ice-Cube" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalIce-Cube" tabindex="-1" role="dialog" aria-labelledby="Ice-Cube" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7795,7 +7795,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="rolling eye" data-quality="4" data-type="Passive">
-                        <a href="#modalRolling-Eye" data-toggle="modal"><img alt="Rolling Eye" title="Rolling Eye" class="gameObject gameObject-Rolling-Eye" src="/img/trans.png"></a>
+                        <a href="#modalRolling-Eye" data-toggle="modal"><img alt="Rolling Eye" title="Rolling Eye" class="gameObject gameObject-Rolling-Eye" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRolling-Eye" tabindex="-1" role="dialog" aria-labelledby="Rolling-Eye" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7815,7 +7815,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="cigarettes" data-quality="5" data-type="Active">
-                        <a href="#modalCigarettes" data-toggle="modal"><img alt="Cigarettes" title="Cigarettes" class="gameObject gameObject-Cigarettes" src="/img/trans.png"></a>
+                        <a href="#modalCigarettes" data-toggle="modal"><img alt="Cigarettes" title="Cigarettes" class="gameObject gameObject-Cigarettes" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCigarettes" tabindex="-1" role="dialog" aria-labelledby="Cigarettes" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7835,7 +7835,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="charm horn" data-quality="3" data-type="Active">
-                        <a href="#modalCharm-Horn" data-toggle="modal"><img alt="Charm Horn" title="Charm Horn" class="gameObject gameObject-Charm-Horn" src="/img/trans.png"></a>
+                        <a href="#modalCharm-Horn" data-toggle="modal"><img alt="Charm Horn" title="Charm Horn" class="gameObject gameObject-Charm-Horn" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCharm-Horn" tabindex="-1" role="dialog" aria-labelledby="Charm-Horn" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7855,7 +7855,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="cog of battle" data-quality="5" data-type="Passive">
-                        <a href="#modalCog-of-Battle" data-toggle="modal"><img alt="Cog of Battle" title="Cog of Battle" class="gameObject gameObject-Cog-of-Battle" src="/img/trans.png"></a>
+                        <a href="#modalCog-of-Battle" data-toggle="modal"><img alt="Cog of Battle" title="Cog of Battle" class="gameObject gameObject-Cog-of-Battle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCog-of-Battle" tabindex="-1" role="dialog" aria-labelledby="Cog-of-Battle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7875,7 +7875,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="metronome" data-quality="3" data-type="Passive">
-                        <a href="#modalMetronome" data-toggle="modal"><img alt="Metronome" title="Metronome" class="gameObject gameObject-Metronome" src="/img/trans.png"></a>
+                        <a href="#modalMetronome" data-toggle="modal"><img alt="Metronome" title="Metronome" class="gameObject gameObject-Metronome" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMetronome" tabindex="-1" role="dialog" aria-labelledby="Metronome" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7895,7 +7895,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="honeycomb" data-quality="3" data-type="Passive">
-                        <a href="#modalHoneycomb" data-toggle="modal"><img alt="Honeycomb" title="Honeycomb" class="gameObject gameObject-Honeycomb" src="/img/trans.png"></a>
+                        <a href="#modalHoneycomb" data-toggle="modal"><img alt="Honeycomb" title="Honeycomb" class="gameObject gameObject-Honeycomb" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHoneycomb" tabindex="-1" role="dialog" aria-labelledby="Honeycomb" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7915,7 +7915,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="map" data-quality="5" data-type="Passive">
-                        <a href="#modalMap" data-toggle="modal"><img alt="Map" title="Map" class="gameObject gameObject-Map" src="/img/trans.png"></a>
+                        <a href="#modalMap" data-toggle="modal"><img alt="Map" title="Map" class="gameObject gameObject-Map" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMap" tabindex="-1" role="dialog" aria-labelledby="Map" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7935,7 +7935,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gungeon blueprint" data-quality="1" data-type="Passive">
-                        <a href="#modalGungeon-Blueprint" data-toggle="modal"><img alt="Gungeon Blueprint" title="Gungeon Blueprint" class="gameObject gameObject-Gungeon-Blueprint" src="/img/trans.png"></a>
+                        <a href="#modalGungeon-Blueprint" data-toggle="modal"><img alt="Gungeon Blueprint" title="Gungeon Blueprint" class="gameObject gameObject-Gungeon-Blueprint" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGungeon-Blueprint" tabindex="-1" role="dialog" aria-labelledby="Gungeon-Blueprint" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7955,7 +7955,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="sense of direction" data-quality="5" data-type="Active">
-                        <a href="#modalSense-of-Direction" data-toggle="modal"><img alt="Sense of Direction" title="Sense of Direction" class="gameObject gameObject-Sense-of-Direction" src="/img/trans.png"></a>
+                        <a href="#modalSense-of-Direction" data-toggle="modal"><img alt="Sense of Direction" title="Sense of Direction" class="gameObject gameObject-Sense-of-Direction" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSense-of-Direction" tabindex="-1" role="dialog" aria-labelledby="Sense-of-Direction" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7975,7 +7975,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="duct tape" data-quality="2" data-type="Active">
-                        <a href="#modalDuct-Tape" data-toggle="modal"><img alt="Duct Tape" title="Duct Tape" class="gameObject gameObject-Duct-Tape" src="/img/trans.png"></a>
+                        <a href="#modalDuct-Tape" data-toggle="modal"><img alt="Duct Tape" title="Duct Tape" class="gameObject gameObject-Duct-Tape" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDuct-Tape" tabindex="-1" role="dialog" aria-labelledby="Duct-Tape" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -7995,7 +7995,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gungeon pepper" data-quality="4" data-type="Passive">
-                        <a href="#modalGungeon-Pepper" data-toggle="modal"><img alt="Gungeon Pepper" title="Gungeon Pepper" class="gameObject gameObject-Gungeon-Pepper" src="/img/trans.png"></a>
+                        <a href="#modalGungeon-Pepper" data-toggle="modal"><img alt="Gungeon Pepper" title="Gungeon Pepper" class="gameObject gameObject-Gungeon-Pepper" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGungeon-Pepper" tabindex="-1" role="dialog" aria-labelledby="Gungeon-Pepper" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8015,7 +8015,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="antibody" data-quality="3" data-type="Passive">
-                        <a href="#modalAntibody" data-toggle="modal"><img alt="Antibody" title="Antibody" class="gameObject gameObject-Antibody" src="/img/trans.png"></a>
+                        <a href="#modalAntibody" data-toggle="modal"><img alt="Antibody" title="Antibody" class="gameObject gameObject-Antibody" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAntibody" tabindex="-1" role="dialog" aria-labelledby="Antibody" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8035,7 +8035,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="pink guon stone" data-quality="3" data-type="Passive">
-                        <a href="#modalPink-Guon-Stone" data-toggle="modal"><img alt="Pink Guon Stone" title="Pink Guon Stone" class="gameObject gameObject-Pink-Guon-Stone" src="/img/trans.png"></a>
+                        <a href="#modalPink-Guon-Stone" data-toggle="modal"><img alt="Pink Guon Stone" title="Pink Guon Stone" class="gameObject gameObject-Pink-Guon-Stone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPink-Guon-Stone" tabindex="-1" role="dialog" aria-labelledby="Pink-Guon-Stone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8055,7 +8055,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="white guon stone" data-quality="3" data-type="Passive">
-                        <a href="#modalWhite-Guon-Stone" data-toggle="modal"><img alt="White Guon Stone" title="White Guon Stone" class="gameObject gameObject-White-Guon-Stone" src="/img/trans.png"></a>
+                        <a href="#modalWhite-Guon-Stone" data-toggle="modal"><img alt="White Guon Stone" title="White Guon Stone" class="gameObject gameObject-White-Guon-Stone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWhite-Guon-Stone" tabindex="-1" role="dialog" aria-labelledby="White-Guon-Stone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8075,7 +8075,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="orange guon stone" data-quality="2" data-type="Passive">
-                        <a href="#modalOrange-Guon-Stone" data-toggle="modal"><img alt="Orange Guon Stone" title="Orange Guon Stone" class="gameObject gameObject-Orange-Guon-Stone" src="/img/trans.png"></a>
+                        <a href="#modalOrange-Guon-Stone" data-toggle="modal"><img alt="Orange Guon Stone" title="Orange Guon Stone" class="gameObject gameObject-Orange-Guon-Stone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOrange-Guon-Stone" tabindex="-1" role="dialog" aria-labelledby="Orange-Guon-Stone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8095,7 +8095,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="clear guon stone" data-quality="3" data-type="Passive">
-                        <a href="#modalClear-Guon-Stone" data-toggle="modal"><img alt="Clear Guon Stone" title="Clear Guon Stone" class="gameObject gameObject-Clear-Guon-Stone" src="/img/trans.png"></a>
+                        <a href="#modalClear-Guon-Stone" data-toggle="modal"><img alt="Clear Guon Stone" title="Clear Guon Stone" class="gameObject gameObject-Clear-Guon-Stone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalClear-Guon-Stone" tabindex="-1" role="dialog" aria-labelledby="Clear-Guon-Stone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8115,7 +8115,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="green guon stone" data-quality="1" data-type="Passive">
-                        <a href="#modalGreen-Guon-Stone" data-toggle="modal"><img alt="Green Guon Stone" title="Green Guon Stone" class="gameObject gameObject-Green-Guon-Stone" src="/img/trans.png"></a>
+                        <a href="#modalGreen-Guon-Stone" data-toggle="modal"><img alt="Green Guon Stone" title="Green Guon Stone" class="gameObject gameObject-Green-Guon-Stone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGreen-Guon-Stone" tabindex="-1" role="dialog" aria-labelledby="Green-Guon-Stone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8135,7 +8135,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="red guon stone" data-quality="3" data-type="Passive">
-                        <a href="#modalRed-Guon-Stone" data-toggle="modal"><img alt="Red Guon Stone" title="Red Guon Stone" class="gameObject gameObject-Red-Guon-Stone" src="/img/trans.png"></a>
+                        <a href="#modalRed-Guon-Stone" data-toggle="modal"><img alt="Red Guon Stone" title="Red Guon Stone" class="gameObject gameObject-Red-Guon-Stone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRed-Guon-Stone" tabindex="-1" role="dialog" aria-labelledby="Red-Guon-Stone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8155,7 +8155,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="blue guon stone" data-quality="3" data-type="Passive">
-                        <a href="#modalBlue-Guon-Stone" data-toggle="modal"><img alt="Blue Guon Stone" title="Blue Guon Stone" class="gameObject gameObject-Blue-Guon-Stone" src="/img/trans.png"></a>
+                        <a href="#modalBlue-Guon-Stone" data-toggle="modal"><img alt="Blue Guon Stone" title="Blue Guon Stone" class="gameObject gameObject-Blue-Guon-Stone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlue-Guon-Stone" tabindex="-1" role="dialog" aria-labelledby="Blue-Guon-Stone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8175,7 +8175,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="iron coin" data-quality="3" data-type="Active">
-                        <a href="#modalIron-Coin" data-toggle="modal"><img alt="Iron Coin" title="Iron Coin" class="gameObject gameObject-Iron-Coin" src="/img/trans.png"></a>
+                        <a href="#modalIron-Coin" data-toggle="modal"><img alt="Iron Coin" title="Iron Coin" class="gameObject gameObject-Iron-Coin" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalIron-Coin" tabindex="-1" role="dialog" aria-labelledby="Iron-Coin" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8195,7 +8195,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="super hot watch" data-quality="1" data-type="Passive">
-                        <a href="#modalSuper-Hot-Watch" data-toggle="modal"><img alt="Super Hot Watch" title="Super Hot Watch" class="gameObject gameObject-Super-Hot-Watch" src="/img/trans.png"></a>
+                        <a href="#modalSuper-Hot-Watch" data-toggle="modal"><img alt="Super Hot Watch" title="Super Hot Watch" class="gameObject gameObject-Super-Hot-Watch" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSuper-Hot-Watch" tabindex="-1" role="dialog" aria-labelledby="Super-Hot-Watch" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8215,7 +8215,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="drum clip" data-quality="3" data-type="Passive">
-                        <a href="#modalDrum-Clip" data-toggle="modal"><img alt="Drum Clip" title="Drum Clip" class="gameObject gameObject-Drum-Clip" src="/img/trans.png"></a>
+                        <a href="#modalDrum-Clip" data-toggle="modal"><img alt="Drum Clip" title="Drum Clip" class="gameObject gameObject-Drum-Clip" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDrum-Clip" tabindex="-1" role="dialog" aria-labelledby="Drum-Clip" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8235,7 +8235,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="blood brooch" data-quality="2" data-type="Passive">
-                        <a href="#modalBlood-Brooch" data-toggle="modal"><img alt="Blood Brooch" title="Blood Brooch" class="gameObject gameObject-Blood-Brooch" src="/img/trans.png"></a>
+                        <a href="#modalBlood-Brooch" data-toggle="modal"><img alt="Blood Brooch" title="Blood Brooch" class="gameObject gameObject-Blood-Brooch" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlood-Brooch" tabindex="-1" role="dialog" aria-labelledby="Blood-Brooch" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8255,7 +8255,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="backup gun" data-quality="3" data-type="Passive">
-                        <a href="#modalBackup-Gun" data-toggle="modal"><img alt="Backup Gun" title="Backup Gun" class="gameObject gameObject-Backup-Gun" src="/img/trans.png"></a>
+                        <a href="#modalBackup-Gun" data-toggle="modal"><img alt="Backup Gun" title="Backup Gun" class="gameObject gameObject-Backup-Gun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBackup-Gun" tabindex="-1" role="dialog" aria-labelledby="Backup-Gun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8275,7 +8275,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="sunglasses" data-quality="4" data-type="Passive">
-                        <a href="#modalSunglasses" data-toggle="modal"><img alt="Sunglasses" title="Sunglasses" class="gameObject gameObject-Sunglasses" src="/img/trans.png"></a>
+                        <a href="#modalSunglasses" data-toggle="modal"><img alt="Sunglasses" title="Sunglasses" class="gameObject gameObject-Sunglasses" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSunglasses" tabindex="-1" role="dialog" aria-labelledby="Sunglasses" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8295,7 +8295,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="mimic tooth necklace" data-quality="2" data-type="Passive">
-                        <a href="#modalMimic-Tooth-Necklace" data-toggle="modal"><img alt="Mimic Tooth Necklace" title="Mimic Tooth Necklace" class="gameObject gameObject-Mimic-Tooth-Necklace" src="/img/trans.png"></a>
+                        <a href="#modalMimic-Tooth-Necklace" data-toggle="modal"><img alt="Mimic Tooth Necklace" title="Mimic Tooth Necklace" class="gameObject gameObject-Mimic-Tooth-Necklace" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMimic-Tooth-Necklace" tabindex="-1" role="dialog" aria-labelledby="Mimic-Tooth-Necklace" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8315,7 +8315,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="escape rope" data-quality="4" data-type="Active">
-                        <a href="#modalEscape-Rope" data-toggle="modal"><img alt="Escape Rope" title="Escape Rope" class="gameObject gameObject-Escape-Rope" src="/img/trans.png"></a>
+                        <a href="#modalEscape-Rope" data-toggle="modal"><img alt="Escape Rope" title="Escape Rope" class="gameObject gameObject-Escape-Rope" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalEscape-Rope" tabindex="-1" role="dialog" aria-labelledby="Escape-Rope" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8335,7 +8335,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="jetpack" data-quality="4" data-type="Active">
-                        <a href="#modalJetpack" data-toggle="modal"><img alt="Jetpack" title="Jetpack" class="gameObject gameObject-Jetpack" src="/img/trans.png"></a>
+                        <a href="#modalJetpack" data-toggle="modal"><img alt="Jetpack" title="Jetpack" class="gameObject gameObject-Jetpack" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalJetpack" tabindex="-1" role="dialog" aria-labelledby="Jetpack" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8355,7 +8355,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="wax wings" data-quality="3" data-type="Passive">
-                        <a href="#modalWax-Wings" data-toggle="modal"><img alt="Wax Wings" title="Wax Wings" class="gameObject gameObject-Wax-Wings" src="/img/trans.png"></a>
+                        <a href="#modalWax-Wings" data-toggle="modal"><img alt="Wax Wings" title="Wax Wings" class="gameObject gameObject-Wax-Wings" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWax-Wings" tabindex="-1" role="dialog" aria-labelledby="Wax-Wings" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8375,7 +8375,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="blast helmet" data-quality="5" data-type="Passive">
-                        <a href="#modalBlast-Helmet" data-toggle="modal"><img alt="Blast Helmet" title="Blast Helmet" class="gameObject gameObject-Blast-Helmet" src="/img/trans.png"></a>
+                        <a href="#modalBlast-Helmet" data-toggle="modal"><img alt="Blast Helmet" title="Blast Helmet" class="gameObject gameObject-Blast-Helmet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlast-Helmet" tabindex="-1" role="dialog" aria-labelledby="Blast-Helmet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8395,7 +8395,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="monster blood" data-quality="4" data-type="Passive">
-                        <a href="#modalMonster-Blood" data-toggle="modal"><img alt="Monster Blood" title="Monster Blood" class="gameObject gameObject-Monster-Blood" src="/img/trans.png"></a>
+                        <a href="#modalMonster-Blood" data-toggle="modal"><img alt="Monster Blood" title="Monster Blood" class="gameObject gameObject-Monster-Blood" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMonster-Blood" tabindex="-1" role="dialog" aria-labelledby="Monster-Blood" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8415,7 +8415,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="nanomachines" data-quality="3" data-type="Passive">
-                        <a href="#modalNanomachines" data-toggle="modal"><img alt="Nanomachines" title="Nanomachines" class="gameObject gameObject-Nanomachines" src="/img/trans.png"></a>
+                        <a href="#modalNanomachines" data-toggle="modal"><img alt="Nanomachines" title="Nanomachines" class="gameObject gameObject-Nanomachines" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalNanomachines" tabindex="-1" role="dialog" aria-labelledby="Nanomachines" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8435,7 +8435,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="seven-leaf clover" data-quality="1" data-type="Passive">
-                        <a href="#modalSeven-Leaf-Clover" data-toggle="modal"><img alt="Seven-Leaf Clover" title="Seven-Leaf Clover" class="gameObject gameObject-Seven-Leaf-Clover" src="/img/trans.png"></a>
+                        <a href="#modalSeven-Leaf-Clover" data-toggle="modal"><img alt="Seven-Leaf Clover" title="Seven-Leaf Clover" class="gameObject gameObject-Seven-Leaf-Clover" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSeven-Leaf-Clover" tabindex="-1" role="dialog" aria-labelledby="Seven-Leaf-Clover" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8455,7 +8455,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="number 2" data-quality="6" data-type="Passive">
-                        <a href="#modalNumber-2" data-toggle="modal"><img alt="Number 2" title="Number 2" class="gameObject gameObject-Number-2" src="/img/trans.png"></a>
+                        <a href="#modalNumber-2" data-toggle="modal"><img alt="Number 2" title="Number 2" class="gameObject gameObject-Number-2" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalNumber-2" tabindex="-1" role="dialog" aria-labelledby="Number-2" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8475,7 +8475,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gold ammolet" data-quality="2" data-type="Passive">
-                        <a href="#modalGold-Ammolet" data-toggle="modal"><img alt="Gold Ammolet" title="Gold Ammolet" class="gameObject gameObject-Gold-Ammolet" src="/img/trans.png"></a>
+                        <a href="#modalGold-Ammolet" data-toggle="modal"><img alt="Gold Ammolet" title="Gold Ammolet" class="gameObject gameObject-Gold-Ammolet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGold-Ammolet" tabindex="-1" role="dialog" aria-labelledby="Gold-Ammolet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8495,7 +8495,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="chaos ammolet" data-quality="2" data-type="Passive">
-                        <a href="#modalChaos-Ammolet" data-toggle="modal"><img alt="Chaos Ammolet" title="Chaos Ammolet" class="gameObject gameObject-Chaos-Ammolet" src="/img/trans.png"></a>
+                        <a href="#modalChaos-Ammolet" data-toggle="modal"><img alt="Chaos Ammolet" title="Chaos Ammolet" class="gameObject gameObject-Chaos-Ammolet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalChaos-Ammolet" tabindex="-1" role="dialog" aria-labelledby="Chaos-Ammolet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8515,7 +8515,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="lodestone ammolet" data-quality="5" data-type="Passive">
-                        <a href="#modalLodestone-Ammolet" data-toggle="modal"><img alt="Lodestone Ammolet" title="Lodestone Ammolet" class="gameObject gameObject-Lodestone-Ammolet" src="/img/trans.png"></a>
+                        <a href="#modalLodestone-Ammolet" data-toggle="modal"><img alt="Lodestone Ammolet" title="Lodestone Ammolet" class="gameObject gameObject-Lodestone-Ammolet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLodestone-Ammolet" tabindex="-1" role="dialog" aria-labelledby="Lodestone-Ammolet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8535,7 +8535,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="uranium ammolet" data-quality="3" data-type="Passive">
-                        <a href="#modalUranium-Ammolet" data-toggle="modal"><img alt="Uranium Ammolet" title="Uranium Ammolet" class="gameObject gameObject-Uranium-Ammolet" src="/img/trans.png"></a>
+                        <a href="#modalUranium-Ammolet" data-toggle="modal"><img alt="Uranium Ammolet" title="Uranium Ammolet" class="gameObject gameObject-Uranium-Ammolet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalUranium-Ammolet" tabindex="-1" role="dialog" aria-labelledby="Uranium-Ammolet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8555,7 +8555,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="copper ammolet" data-quality="3" data-type="Passive">
-                        <a href="#modalCopper-Ammolet" data-toggle="modal"><img alt="Copper Ammolet" title="Copper Ammolet" class="gameObject gameObject-Copper-Ammolet" src="/img/trans.png"></a>
+                        <a href="#modalCopper-Ammolet" data-toggle="modal"><img alt="Copper Ammolet" title="Copper Ammolet" class="gameObject gameObject-Copper-Ammolet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCopper-Ammolet" tabindex="-1" role="dialog" aria-labelledby="Copper-Ammolet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8575,7 +8575,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="frost ammolet" data-quality="3" data-type="Passive">
-                        <a href="#modalFrost-Ammolet" data-toggle="modal"><img alt="Frost Ammolet" title="Frost Ammolet" class="gameObject gameObject-Frost-Ammolet" src="/img/trans.png"></a>
+                        <a href="#modalFrost-Ammolet" data-toggle="modal"><img alt="Frost Ammolet" title="Frost Ammolet" class="gameObject gameObject-Frost-Ammolet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalFrost-Ammolet" tabindex="-1" role="dialog" aria-labelledby="Frost-Ammolet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8595,7 +8595,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="table tech sight" data-quality="5" data-type="Passive">
-                        <a href="#modalTable-Tech-Sight" data-toggle="modal"><img alt="Table Tech Sight" title="Table Tech Sight" class="gameObject gameObject-Table-Tech-Sight" src="/img/trans.png"></a>
+                        <a href="#modalTable-Tech-Sight" data-toggle="modal"><img alt="Table Tech Sight" title="Table Tech Sight" class="gameObject gameObject-Table-Tech-Sight" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTable-Tech-Sight" tabindex="-1" role="dialog" aria-labelledby="Table-Tech-Sight" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8615,7 +8615,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="table tech money" data-quality="5" data-type="Passive">
-                        <a href="#modalTable-Tech-Money" data-toggle="modal"><img alt="Table Tech Money" title="Table Tech Money" class="gameObject gameObject-Table-Tech-Money" src="/img/trans.png"></a>
+                        <a href="#modalTable-Tech-Money" data-toggle="modal"><img alt="Table Tech Money" title="Table Tech Money" class="gameObject gameObject-Table-Tech-Money" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTable-Tech-Money" tabindex="-1" role="dialog" aria-labelledby="Table-Tech-Money" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8635,7 +8635,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="table tech rocket" data-quality="4" data-type="Passive">
-                        <a href="#modalTable-Tech-Rocket" data-toggle="modal"><img alt="Table Tech Rocket" title="Table Tech Rocket" class="gameObject gameObject-Table-Tech-Rocket" src="/img/trans.png"></a>
+                        <a href="#modalTable-Tech-Rocket" data-toggle="modal"><img alt="Table Tech Rocket" title="Table Tech Rocket" class="gameObject gameObject-Table-Tech-Rocket" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTable-Tech-Rocket" tabindex="-1" role="dialog" aria-labelledby="Table-Tech-Rocket" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8655,7 +8655,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="table tech rage" data-quality="5" data-type="Passive">
-                        <a href="#modalTable-Tech-Rage" data-toggle="modal"><img alt="Table Tech Rage" title="Table Tech Rage" class="gameObject gameObject-Table-Tech-Rage" src="/img/trans.png"></a>
+                        <a href="#modalTable-Tech-Rage" data-toggle="modal"><img alt="Table Tech Rage" title="Table Tech Rage" class="gameObject gameObject-Table-Tech-Rage" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTable-Tech-Rage" tabindex="-1" role="dialog" aria-labelledby="Table-Tech-Rage" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8675,7 +8675,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="table tech blanks" data-quality="4" data-type="Passive">
-                        <a href="#modalTable-Tech-Blanks" data-toggle="modal"><img alt="Table Tech Blanks" title="Table Tech Blanks" class="gameObject gameObject-Table-Tech-Blanks" src="/img/trans.png"></a>
+                        <a href="#modalTable-Tech-Blanks" data-toggle="modal"><img alt="Table Tech Blanks" title="Table Tech Blanks" class="gameObject gameObject-Table-Tech-Blanks" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTable-Tech-Blanks" tabindex="-1" role="dialog" aria-labelledby="Table-Tech-Blanks" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8695,7 +8695,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="table tech stun" data-quality="4" data-type="Passive">
-                        <a href="#modalTable-Tech-Stun" data-toggle="modal"><img alt="Table Tech Stun" title="Table Tech Stun" class="gameObject gameObject-Table-Tech-Stun" src="/img/trans.png"></a>
+                        <a href="#modalTable-Tech-Stun" data-toggle="modal"><img alt="Table Tech Stun" title="Table Tech Stun" class="gameObject gameObject-Table-Tech-Stun" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalTable-Tech-Stun" tabindex="-1" role="dialog" aria-labelledby="Table-Tech-Stun" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8715,7 +8715,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heart holster" data-quality="2" data-type="Passive">
-                        <a href="#modalHeart-Holster" data-toggle="modal"><img alt="Heart Holster" title="Heart Holster" class="gameObject gameObject-Heart-Holster" src="/img/trans.png"></a>
+                        <a href="#modalHeart-Holster" data-toggle="modal"><img alt="Heart Holster" title="Heart Holster" class="gameObject gameObject-Heart-Holster" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeart-Holster" tabindex="-1" role="dialog" aria-labelledby="Heart-Holster" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8735,7 +8735,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heart lunchbox" data-quality="2" data-type="Passive">
-                        <a href="#modalHeart-Lunchbox" data-toggle="modal"><img alt="Heart Lunchbox" title="Heart Lunchbox" class="gameObject gameObject-Heart-Lunchbox" src="/img/trans.png"></a>
+                        <a href="#modalHeart-Lunchbox" data-toggle="modal"><img alt="Heart Lunchbox" title="Heart Lunchbox" class="gameObject gameObject-Heart-Lunchbox" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeart-Lunchbox" tabindex="-1" role="dialog" aria-labelledby="Heart-Lunchbox" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8755,7 +8755,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heart locket" data-quality="2" data-type="Passive">
-                        <a href="#modalHeart-Locket" data-toggle="modal"><img alt="Heart Locket" title="Heart Locket" class="gameObject gameObject-Heart-Locket" src="/img/trans.png"></a>
+                        <a href="#modalHeart-Locket" data-toggle="modal"><img alt="Heart Locket" title="Heart Locket" class="gameObject gameObject-Heart-Locket" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeart-Locket" tabindex="-1" role="dialog" aria-labelledby="Heart-Locket" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8775,7 +8775,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heart bottle" data-quality="2" data-type="Passive">
-                        <a href="#modalHeart-Bottle" data-toggle="modal"><img alt="Heart Bottle" title="Heart Bottle" class="gameObject gameObject-Heart-Bottle" src="/img/trans.png"></a>
+                        <a href="#modalHeart-Bottle" data-toggle="modal"><img alt="Heart Bottle" title="Heart Bottle" class="gameObject gameObject-Heart-Bottle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeart-Bottle" tabindex="-1" role="dialog" aria-labelledby="Heart-Bottle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8795,7 +8795,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heart purse" data-quality="2" data-type="Passive">
-                        <a href="#modalHeart-Purse" data-toggle="modal"><img alt="Heart Purse" title="Heart Purse" class="gameObject gameObject-Heart-Purse" src="/img/trans.png"></a>
+                        <a href="#modalHeart-Purse" data-toggle="modal"><img alt="Heart Purse" title="Heart Purse" class="gameObject gameObject-Heart-Purse" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeart-Purse" tabindex="-1" role="dialog" aria-labelledby="Heart-Purse" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8815,7 +8815,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ruby bracelet" data-quality="5" data-type="Passive">
-                        <a href="#modalRuby-Bracelet" data-toggle="modal"><img alt="Ruby Bracelet" title="Ruby Bracelet" class="gameObject gameObject-Ruby-Bracelet" src="/img/trans.png"></a>
+                        <a href="#modalRuby-Bracelet" data-toggle="modal"><img alt="Ruby Bracelet" title="Ruby Bracelet" class="gameObject gameObject-Ruby-Bracelet" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRuby-Bracelet" tabindex="-1" role="dialog" aria-labelledby="Ruby-Bracelet" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8835,7 +8835,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="sixth chamber" data-quality="2" data-type="Passive">
-                        <a href="#modalSixth-Chamber" data-toggle="modal"><img alt="Sixth Chamber" title="Sixth Chamber" class="gameObject gameObject-Sixth-Chamber" src="/img/trans.png"></a>
+                        <a href="#modalSixth-Chamber" data-toggle="modal"><img alt="Sixth Chamber" title="Sixth Chamber" class="gameObject gameObject-Sixth-Chamber" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSixth-Chamber" tabindex="-1" role="dialog" aria-labelledby="Sixth-Chamber" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8855,7 +8855,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="busted television" data-quality="6" data-type="Active">
-                        <a href="#modalBusted-Television" data-toggle="modal"><img alt="Busted Television" title="Busted Television" class="gameObject gameObject-Busted-Television" src="/img/trans.png"></a>
+                        <a href="#modalBusted-Television" data-toggle="modal"><img alt="Busted Television" title="Busted Television" class="gameObject gameObject-Busted-Television" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBusted-Television" tabindex="-1" role="dialog" aria-labelledby="Busted-Television" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8875,7 +8875,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="coolant leak" data-quality="6" data-type="Active">
-                        <a href="#modalCoolant-Leak" data-toggle="modal"><img alt="Coolant Leak" title="Coolant Leak" class="gameObject gameObject-Coolant-Leak" src="/img/trans.png"></a>
+                        <a href="#modalCoolant-Leak" data-toggle="modal"><img alt="Coolant Leak" title="Coolant Leak" class="gameObject gameObject-Coolant-Leak" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalCoolant-Leak" tabindex="-1" role="dialog" aria-labelledby="Coolant-Leak" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8895,7 +8895,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="heart of ice" data-quality="1" data-type="Passive">
-                        <a href="#modalHeart-of-Ice" data-toggle="modal"><img alt="Heart of Ice" title="Heart of Ice" class="gameObject gameObject-Heart-of-Ice" src="/img/trans.png"></a>
+                        <a href="#modalHeart-of-Ice" data-toggle="modal"><img alt="Heart of Ice" title="Heart of Ice" class="gameObject gameObject-Heart-of-Ice" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHeart-of-Ice" tabindex="-1" role="dialog" aria-labelledby="Heart-of-Ice" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8915,7 +8915,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="ancient hero's bandana" data-quality="1" data-type="Passive">
-                        <a href="#modalAncient-Hero_s-Bandana" data-toggle="modal"><img alt="Ancient Hero's Bandana" title="Ancient Hero's Bandana" class="gameObject gameObject-Ancient-Hero_s-Bandana" src="/img/trans.png"></a>
+                        <a href="#modalAncient-Hero_s-Bandana" data-toggle="modal"><img alt="Ancient Hero's Bandana" title="Ancient Hero's Bandana" class="gameObject gameObject-Ancient-Hero_s-Bandana" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalAncient-Hero_s-Bandana" tabindex="-1" role="dialog" aria-labelledby="Ancient-Hero_s-Bandana" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8935,7 +8935,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bloodied scarf" data-quality="3" data-type="Passive">
-                        <a href="#modalBloodied-Scarf" data-toggle="modal"><img alt="Bloodied Scarf" title="Bloodied Scarf" class="gameObject gameObject-Bloodied-Scarf" src="/img/trans.png"></a>
+                        <a href="#modalBloodied-Scarf" data-toggle="modal"><img alt="Bloodied Scarf" title="Bloodied Scarf" class="gameObject gameObject-Bloodied-Scarf" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBloodied-Scarf" tabindex="-1" role="dialog" aria-labelledby="Bloodied-Scarf" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8955,7 +8955,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="muscle relaxant" data-quality="3" data-type="Passive">
-                        <a href="#modalMuscle-Relaxant" data-toggle="modal"><img alt="Muscle Relaxant" title="Muscle Relaxant" class="gameObject gameObject-Muscle-Relaxant" src="/img/trans.png"></a>
+                        <a href="#modalMuscle-Relaxant" data-toggle="modal"><img alt="Muscle Relaxant" title="Muscle Relaxant" class="gameObject gameObject-Muscle-Relaxant" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMuscle-Relaxant" tabindex="-1" role="dialog" aria-labelledby="Muscle-Relaxant" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8975,7 +8975,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="hip holster" data-quality="3" data-type="Passive">
-                        <a href="#modalHip-Holster" data-toggle="modal"><img alt="Hip Holster" title="Hip Holster" class="gameObject gameObject-Hip-Holster" src="/img/trans.png"></a>
+                        <a href="#modalHip-Holster" data-toggle="modal"><img alt="Hip Holster" title="Hip Holster" class="gameObject gameObject-Hip-Holster" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHip-Holster" tabindex="-1" role="dialog" aria-labelledby="Hip-Holster" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -8995,7 +8995,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="clone" data-quality="1" data-type="Passive">
-                        <a href="#modalClone" data-toggle="modal"><img alt="Clone" title="Clone" class="gameObject gameObject-Clone" src="/img/trans.png"></a>
+                        <a href="#modalClone" data-toggle="modal"><img alt="Clone" title="Clone" class="gameObject gameObject-Clone" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalClone" tabindex="-1" role="dialog" aria-labelledby="Clone" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9015,7 +9015,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="sponge" data-quality="4" data-type="Passive">
-                        <a href="#modalSponge" data-toggle="modal"><img alt="Sponge" title="Sponge" class="gameObject gameObject-Sponge" src="/img/trans.png"></a>
+                        <a href="#modalSponge" data-toggle="modal"><img alt="Sponge" title="Sponge" class="gameObject gameObject-Sponge" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSponge" tabindex="-1" role="dialog" aria-labelledby="Sponge" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9035,7 +9035,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gas mask" data-quality="5" data-type="Passive">
-                        <a href="#modalGas-Mask" data-toggle="modal"><img alt="Gas Mask" title="Gas Mask" class="gameObject gameObject-Gas-Mask" src="/img/trans.png"></a>
+                        <a href="#modalGas-Mask" data-toggle="modal"><img alt="Gas Mask" title="Gas Mask" class="gameObject gameObject-Gas-Mask" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGas-Mask" tabindex="-1" role="dialog" aria-labelledby="Gas-Mask" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9055,7 +9055,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="hazmat suit" data-quality="3" data-type="Passive">
-                        <a href="#modalHazmat-Suit" data-toggle="modal"><img alt="Hazmat Suit" title="Hazmat Suit" class="gameObject gameObject-Hazmat-Suit" src="/img/trans.png"></a>
+                        <a href="#modalHazmat-Suit" data-toggle="modal"><img alt="Hazmat Suit" title="Hazmat Suit" class="gameObject gameObject-Hazmat-Suit" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalHazmat-Suit" tabindex="-1" role="dialog" aria-labelledby="Hazmat-Suit" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9075,7 +9075,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="book of chest anatomy" data-quality="3" data-type="Passive">
-                        <a href="#modalBook-of-Chest-Anatomy" data-toggle="modal"><img alt="Book of Chest Anatomy" title="Book of Chest Anatomy" class="gameObject gameObject-Book-of-Chest-Anatomy" src="/img/trans.png"></a>
+                        <a href="#modalBook-of-Chest-Anatomy" data-toggle="modal"><img alt="Book of Chest Anatomy" title="Book of Chest Anatomy" class="gameObject gameObject-Book-of-Chest-Anatomy" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBook-of-Chest-Anatomy" tabindex="-1" role="dialog" aria-labelledby="Book-of-Chest-Anatomy" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9095,7 +9095,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="gun soul" data-quality="1" data-type="Passive">
-                        <a href="#modalGun-Soul" data-toggle="modal"><img alt="Gun Soul" title="Gun Soul" class="gameObject gameObject-Gun-Soul" src="/img/trans.png"></a>
+                        <a href="#modalGun-Soul" data-toggle="modal"><img alt="Gun Soul" title="Gun Soul" class="gameObject gameObject-Gun-Soul" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGun-Soul" tabindex="-1" role="dialog" aria-labelledby="Gun-Soul" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9115,7 +9115,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="shelleton key" data-quality="1" data-type="Passive">
-                        <a href="#modalShelleton-Key" data-toggle="modal"><img alt="Shelleton Key" title="Shelleton Key" class="gameObject gameObject-Shelleton-Key" src="/img/trans.png"></a>
+                        <a href="#modalShelleton-Key" data-toggle="modal"><img alt="Shelleton Key" title="Shelleton Key" class="gameObject gameObject-Shelleton-Key" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalShelleton-Key" tabindex="-1" role="dialog" aria-labelledby="Shelleton-Key" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9135,7 +9135,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="brick of cash" data-quality="2" data-type="Passive">
-                        <a href="#modalBrick-of-Cash" data-toggle="modal"><img alt="Brick of Cash" title="Brick of Cash" class="gameObject gameObject-Brick-of-Cash" src="/img/trans.png"></a>
+                        <a href="#modalBrick-of-Cash" data-toggle="modal"><img alt="Brick of Cash" title="Brick of Cash" class="gameObject gameObject-Brick-of-Cash" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBrick-of-Cash" tabindex="-1" role="dialog" aria-labelledby="Brick-of-Cash" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9155,7 +9155,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="wingman" data-quality="2" data-type="Passive">
-                        <a href="#modalWingman" data-toggle="modal"><img alt="Wingman" title="Wingman" class="gameObject gameObject-Wingman" src="/img/trans.png"></a>
+                        <a href="#modalWingman" data-toggle="modal"><img alt="Wingman" title="Wingman" class="gameObject gameObject-Wingman" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWingman" tabindex="-1" role="dialog" aria-labelledby="Wingman" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9175,7 +9175,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="wolf" data-quality="3" data-type="Passive">
-                        <a href="#modalWolf" data-toggle="modal"><img alt="Wolf" title="Wolf" class="gameObject gameObject-Wolf" src="/img/trans.png"></a>
+                        <a href="#modalWolf" data-toggle="modal"><img alt="Wolf" title="Wolf" class="gameObject gameObject-Wolf" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalWolf" tabindex="-1" role="dialog" aria-labelledby="Wolf" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9195,7 +9195,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="dog" data-quality="5" data-type="Passive">
-                        <a href="#modalDog" data-toggle="modal"><img alt="Dog" title="Dog" class="gameObject gameObject-Dog" src="/img/trans.png"></a>
+                        <a href="#modalDog" data-toggle="modal"><img alt="Dog" title="Dog" class="gameObject gameObject-Dog" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalDog" tabindex="-1" role="dialog" aria-labelledby="Dog" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9215,7 +9215,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="owl" data-quality="1" data-type="Passive">
-                        <a href="#modalOwl" data-toggle="modal"><img alt="Owl" title="Owl" class="gameObject gameObject-Owl" src="/img/trans.png"></a>
+                        <a href="#modalOwl" data-toggle="modal"><img alt="Owl" title="Owl" class="gameObject gameObject-Owl" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalOwl" tabindex="-1" role="dialog" aria-labelledby="Owl" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9235,7 +9235,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="super space turtle" data-quality="3" data-type="Passive">
-                        <a href="#modalSuper-Space-Turtle" data-toggle="modal"><img alt="Super Space Turtle" title="Super Space Turtle" class="gameObject gameObject-Super-Space-Turtle" src="/img/trans.png"></a>
+                        <a href="#modalSuper-Space-Turtle" data-toggle="modal"><img alt="Super Space Turtle" title="Super Space Turtle" class="gameObject gameObject-Super-Space-Turtle" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSuper-Space-Turtle" tabindex="-1" role="dialog" aria-labelledby="Super-Space-Turtle" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9255,7 +9255,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="r2g2" data-quality="1" data-type="Passive">
-                        <a href="#modalR2G2" data-toggle="modal"><img alt="R2G2" title="R2G2" class="gameObject gameObject-R2G2" src="/img/trans.png"></a>
+                        <a href="#modalR2G2" data-toggle="modal"><img alt="R2G2" title="R2G2" class="gameObject gameObject-R2G2" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalR2G2" tabindex="-1" role="dialog" aria-labelledby="R2G2" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9275,7 +9275,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="badge" data-quality="2" data-type="Passive">
-                        <a href="#modalBadge" data-toggle="modal"><img alt="Badge" title="Badge" class="gameObject gameObject-Badge" src="/img/trans.png"></a>
+                        <a href="#modalBadge" data-toggle="modal"><img alt="Badge" title="Badge" class="gameObject gameObject-Badge" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBadge" tabindex="-1" role="dialog" aria-labelledby="Badge" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9295,7 +9295,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="space friend" data-quality="3" data-type="Passive">
-                        <a href="#modalSpace-Friend" data-toggle="modal"><img alt="Space Friend" title="Space Friend" class="gameObject gameObject-Space-Friend" src="/img/trans.png"></a>
+                        <a href="#modalSpace-Friend" data-toggle="modal"><img alt="Space Friend" title="Space Friend" class="gameObject gameObject-Space-Friend" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSpace-Friend" tabindex="-1" role="dialog" aria-labelledby="Space-Friend" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9315,7 +9315,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="pig" data-quality="2" data-type="Passive">
-                        <a href="#modalPig" data-toggle="modal"><img alt="Pig" title="Pig" class="gameObject gameObject-Pig" src="/img/trans.png"></a>
+                        <a href="#modalPig" data-toggle="modal"><img alt="Pig" title="Pig" class="gameObject gameObject-Pig" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalPig" tabindex="-1" role="dialog" aria-labelledby="Pig" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9335,7 +9335,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="blank companion's ring" data-quality="2" data-type="Passive">
-                        <a href="#modalBlank-Companion_s-Ring" data-toggle="modal"><img alt="Blank Companion's Ring" title="Blank Companion's Ring" class="gameObject gameObject-Blank-Companion_s-Ring" src="/img/trans.png"></a>
+                        <a href="#modalBlank-Companion_s-Ring" data-toggle="modal"><img alt="Blank Companion's Ring" title="Blank Companion's Ring" class="gameObject gameObject-Blank-Companion_s-Ring" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBlank-Companion_s-Ring" tabindex="-1" role="dialog" aria-labelledby="Blank-Companion_s-Ring" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9355,7 +9355,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="briefcase of cash" data-quality="2" data-type="Passive">
-                        <a href="#modalBriefcase-of-Cash" data-toggle="modal"><img alt="Briefcase of Cash" title="Briefcase of Cash" class="gameObject gameObject-Briefcase-of-Cash" src="/img/trans.png"></a>
+                        <a href="#modalBriefcase-of-Cash" data-toggle="modal"><img alt="Briefcase of Cash" title="Briefcase of Cash" class="gameObject gameObject-Briefcase-of-Cash" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBriefcase-of-Cash" tabindex="-1" role="dialog" aria-labelledby="Briefcase-of-Cash" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9375,7 +9375,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="galactic medal of valor" data-quality="4" data-type="Passive">
-                        <a href="#modalGalactic-Medal-of-Valor" data-toggle="modal"><img alt="Galactic Medal of Valor" title="Galactic Medal of Valor" class="gameObject gameObject-Galactic-Medal-of-Valor" src="/img/trans.png"></a>
+                        <a href="#modalGalactic-Medal-of-Valor" data-toggle="modal"><img alt="Galactic Medal of Valor" title="Galactic Medal of Valor" class="gameObject gameObject-Galactic-Medal-of-Valor" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalGalactic-Medal-of-Valor" tabindex="-1" role="dialog" aria-labelledby="Galactic-Medal-of-Valor" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9395,7 +9395,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bullet idol" data-quality="3" data-type="Passive">
-                        <a href="#modalBullet-Idol" data-toggle="modal"><img alt="Bullet Idol" title="Bullet Idol" class="gameObject gameObject-Bullet-Idol" src="/img/trans.png"></a>
+                        <a href="#modalBullet-Idol" data-toggle="modal"><img alt="Bullet Idol" title="Bullet Idol" class="gameObject gameObject-Bullet-Idol" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBullet-Idol" tabindex="-1" role="dialog" aria-labelledby="Bullet-Idol" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9415,7 +9415,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="riddle of lead" data-quality="1" data-type="Passive">
-                        <a href="#modalRiddle-of-Lead" data-toggle="modal"><img alt="Riddle of Lead" title="Riddle of Lead" class="gameObject gameObject-Riddle-of-Lead" src="/img/trans.png"></a>
+                        <a href="#modalRiddle-of-Lead" data-toggle="modal"><img alt="Riddle of Lead" title="Riddle of Lead" class="gameObject gameObject-Riddle-of-Lead" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRiddle-of-Lead" tabindex="-1" role="dialog" aria-labelledby="Riddle-of-Lead" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9435,7 +9435,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="bracket key" data-quality="1" data-type="Active">
-                        <a href="#modalBracket-Key" data-toggle="modal"><img alt="Bracket Key" title="Bracket Key" class="gameObject gameObject-Bracket-Key" src="/img/trans.png"></a>
+                        <a href="#modalBracket-Key" data-toggle="modal"><img alt="Bracket Key" title="Bracket Key" class="gameObject gameObject-Bracket-Key" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalBracket-Key" tabindex="-1" role="dialog" aria-labelledby="Bracket-Key" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9455,7 +9455,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="elder blank" data-quality="3" data-type="Active">
-                        <a href="#modalElder-Blank" data-toggle="modal"><img alt="Elder Blank" title="Elder Blank" class="gameObject gameObject-Elder-Blank" src="/img/trans.png"></a>
+                        <a href="#modalElder-Blank" data-toggle="modal"><img alt="Elder Blank" title="Elder Blank" class="gameObject gameObject-Elder-Blank" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalElder-Blank" tabindex="-1" role="dialog" aria-labelledby="Elder-Blank" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9475,7 +9475,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="junk" data-quality="6" data-type="Passive">
-                        <a href="#modalJunk" data-toggle="modal"><img alt="Junk" title="Junk" class="gameObject gameObject-Junk" src="/img/trans.png"></a>
+                        <a href="#modalJunk" data-toggle="modal"><img alt="Junk" title="Junk" class="gameObject gameObject-Junk" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalJunk" tabindex="-1" role="dialog" aria-labelledby="Junk" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9495,7 +9495,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="lies" data-quality="6" data-type="Passive">
-                        <a href="#modalLies" data-toggle="modal"><img alt="Lies" title="Lies" class="gameObject gameObject-Lies" src="/img/trans.png"></a>
+                        <a href="#modalLies" data-toggle="modal"><img alt="Lies" title="Lies" class="gameObject gameObject-Lies" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalLies" tabindex="-1" role="dialog" aria-labelledby="Lies" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">
@@ -9515,7 +9515,7 @@
                         </div>
                     </div>
                     <div class="grid-item2" data-name="spice" data-quality="2" data-type="Active">
-                        <a href="#modalSpice" data-toggle="modal"><img alt="Spice" title="Spice" class="gameObject gameObject-Spice" src="/img/trans.png"></a>
+                        <a href="#modalSpice" data-toggle="modal"><img alt="Spice" title="Spice" class="gameObject gameObject-Spice" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalSpice" tabindex="-1" role="dialog" aria-labelledby="Spice" aria-hidden="true">
                             <div class="modal-dialog">
                                 <div class="modal-content">

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
             </div>
             <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">
                 <h1 class="page-header">Weapons</h1>
-                <div class="grid1" id="guns">
+                <div class="item-container grid1" id="guns">
                     <div class="grid-item1" data-name="rusty sidearm" data-quality="6" data-type="Semiautomatic">
                         <a href="#modalRusty-Sidearm" data-toggle="modal"><img alt="Rusty Sidearm" title="Rusty Sidearm" class="gameObject gameObject-Rusty-Sidearm" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalRusty-Sidearm" tabindex="-1" role="dialog" aria-labelledby="Rusty-Sidearm" aria-hidden="true">
@@ -5393,7 +5393,7 @@
                     </div>
                 </div>
                 <h1 class="page-header">Items</h1>
-                <div class="grid2" id="items">
+                <div class="item-container grid2" id="items">
                     <div class="grid-item2" data-name="master round i" data-quality="6" data-type="Passive">
                         <a href="#modalMaster-Round-I" data-toggle="modal"><img alt="Master Round I" title="Master Round I" class="gameObject gameObject-Master-Round-I" src="./img/trans.png"></a>
                         <div class="modal fade" id="modalMaster-Round-I" tabindex="-1" role="dialog" aria-labelledby="Master-Round-I" aria-hidden="true">


### PR DESCRIPTION
General styles are added to each item group's container so they can be styled generically.

There's currently an issue where the <h1> for the item group's title cannot be in the item's container itself, but this is likely because the items are positioned absolutely within so they cover up the <h1>. Addressing that will be the next focus.
